### PR TITLE
Show post-scan results on homepage; remove classify session button

### DIFF
--- a/ts_sdk/src/services/system-tools-service.ts
+++ b/ts_sdk/src/services/system-tools-service.ts
@@ -63,6 +63,20 @@ export interface DbSettings {
 /** The five distinct system activities. */
 export type SystemActivity = 'clear' | 'archive' | 'load_from_archive' | 'scan' | 'index';
 
+export interface ScanTypeStats {
+  type: string;
+  count: number;
+  total_bytes: number;
+  avg_bytes: number;
+  scan_ms: number;
+}
+
+export interface LastScanResult {
+  types: ScanTypeStats[];
+  grand_total: number;
+  scan_ms: number;
+}
+
 /** Per-step progress for multi-step activities (scan / index). */
 export interface ActivityProgress {
   // Orchestration-level (set by resetAndRescan phases)
@@ -109,6 +123,7 @@ export class SystemToolsService extends EventEmitter {
   currentActivity: SystemActivity | null = null;
   activityProgress: ActivityProgress | null = null;
   scanInfo: ScanInfo | null = null;
+  lastScanResult: LastScanResult | null = null;
 
   constructor(userTypeId: { type: string; id: string }) {
     super();
@@ -314,6 +329,7 @@ export class SystemToolsService extends EventEmitter {
    * WS progress_report events drive the activityProgress.current / done / records fields.
    */
   async resetAndRescan(): Promise<void> {
+    let capturedScanResult: LastScanResult | null = null;
     try {
       // 1. Archive
       this._setActivity('archive');
@@ -332,12 +348,16 @@ export class SystemToolsService extends EventEmitter {
 
       // 4. Aggregate scan — WS progress_report events drive current/done/records progress
       this._setActivity('scan', { total: types.length, done: [], current: null, pending: [...types] });
-      await apiClient.get(`${FS_RECORDS_BASE}/scan?trigger=manual`);
+      const scanData = await apiClient.get(`${FS_RECORDS_BASE}/scan?trigger=manual`);
+      const scanResult = scanData as unknown as LastScanResult;
+      if (scanResult?.types) capturedScanResult = scanResult;
 
       // 5. Aggregate index — WS progress_report events drive current/done/records progress
       this._setActivity('index', { total: types.length, done: [], current: null, pending: [...types] });
       await apiClient.post(`${FS_RECORDS_BASE}/index`);
     } finally {
+      // Set lastScanResult before clearing activity so the state_changed event carries both
+      if (capturedScanResult) this.lastScanResult = capturedScanResult;
       this._setActivity(null);
       void dataManager.refreshScanInfo();
     }

--- a/ui/src/components/live-workflow/SessionActionButtons.tsx
+++ b/ui/src/components/live-workflow/SessionActionButtons.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@src/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@src/components/ui/tooltip';
-import { ScanSearch, Terminal } from 'lucide-react';
-import { useSessionClassify } from '@src/hooks/use-session-classify';
+import { Terminal } from 'lucide-react';
 import { useResumeInTerminal } from '@src/hooks/use-resume-in-terminal';
 
 interface SessionActionButtonsProps {
@@ -10,12 +9,15 @@ interface SessionActionButtonsProps {
 }
 
 /**
- * Classify + Resume-in-terminal buttons for a Claude CLI session.
+ * Resume-in-terminal button for a Claude CLI session.
  * Reusable across SessionViewer, SessionTabBar, or any header that
  * shows actions for a live session.
  */
-function ResumeButton({ sessionId, sessionCwd }: { sessionId: string; sessionCwd?: string }) {
+export function SessionActionButtons({ workerSessionId, sessionCwd }: SessionActionButtonsProps) {
   const { resumeInTerminal } = useResumeInTerminal();
+
+  if (!workerSessionId) return null;
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -23,49 +25,12 @@ function ResumeButton({ sessionId, sessionCwd }: { sessionId: string; sessionCwd
           variant="ghost"
           size="icon"
           className="h-7 w-7"
-          onClick={() => resumeInTerminal(sessionId, sessionCwd)}
+          onClick={() => resumeInTerminal(workerSessionId, sessionCwd)}
         >
           <Terminal className="h-3.5 w-3.5" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">Resume in terminal</TooltipContent>
     </Tooltip>
-  );
-}
-
-export function SessionActionButtons({ workerSessionId, sessionCwd }: SessionActionButtonsProps) {
-  const { classifySession, classifyingSessionIds, classificationExists, isWorkerSession } = useSessionClassify({
-    currentSessionId: workerSessionId ?? undefined,
-  });
-
-  if (!workerSessionId) return null;
-
-  // Hide classify button on worker sessions (sessions created to run classifications)
-  if (isWorkerSession) {
-    return <ResumeButton sessionId={workerSessionId} sessionCwd={sessionCwd} />;
-  }
-
-  const isClassifying = classifyingSessionIds.has(workerSessionId);
-
-  return (
-    <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            disabled={isClassifying || !sessionCwd || classificationExists}
-            onClick={() => sessionCwd && void classifySession(workerSessionId, sessionCwd)}
-          >
-            <ScanSearch className={`h-3.5 w-3.5 ${isClassifying ? 'animate-pulse text-amber-500' : ''}`} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {isClassifying ? 'Classifying...' : classificationExists ? 'Already classified' : 'Classify session'}
-        </TooltipContent>
-      </Tooltip>
-      <ResumeButton sessionId={workerSessionId} sessionCwd={sessionCwd} />
-    </>
   );
 }

--- a/ui/src/components/project-activity-strip/ProjectActivityStrip.tsx
+++ b/ui/src/components/project-activity-strip/ProjectActivityStrip.tsx
@@ -17,7 +17,6 @@ import {
   Maximize2,
   Plug,
   RefreshCw,
-  ScanSearch,
   Search,
   Settings,
   Sparkles,
@@ -107,7 +106,6 @@ interface SessionRowProps {
   item: ProjectResourceListItem;
   classificationTask: Task | null;
   actionTask: Task | null;
-  isWorkerSession: boolean;
   eventCount: number;
   latestEvent: SnifferEvent | null;
   isLoading: boolean;
@@ -115,7 +113,6 @@ interface SessionRowProps {
   onItemClick?: (item: ProjectResourceListItem) => void;
   onSessionResume?: (item: ProjectResourceListItem) => void;
   onSessionTasks?: (item: ProjectResourceListItem) => void;
-  onSessionClassify?: (item: ProjectResourceListItem) => void;
   onActAccordingToClassification?: (item: ProjectResourceListItem, command: string) => void;
   onOpenEventDialog?: (sessionId: string, name: string) => void;
 }
@@ -124,7 +121,6 @@ function SessionRow({
   item,
   classificationTask,
   actionTask,
-  isWorkerSession,
   eventCount,
   latestEvent,
   isLoading,
@@ -132,56 +128,15 @@ function SessionRow({
   onItemClick,
   onSessionResume,
   onSessionTasks,
-  onSessionClassify,
   onActAccordingToClassification,
   onOpenEventDialog,
 }: SessionRowProps) {
-  const { isRunning: isClassifyRunning } = useAnalysisTaskProgress(classificationTask);
   const { isRunning: isActionRunning, isComplete: isActionComplete } = useAnalysisTaskProgress(actionTask);
   const classificationInfo = useClassificationResult(classificationTask);
   const { navigation } = useDockNavigation();
   const timeAgo = formatTimeAgo(item.modifiedAt);
   const actionArtifacts = actionTask ? getArtifactPaths(actionTask) : [];
   const projectLabel = item.path?.split('/').filter(Boolean).pop() ?? null;
-
-  function renderClassifyButton() {
-    // Worker sessions (spawned to run classifications) should not show a classify button
-    if (isWorkerSession) return null;
-
-    const isRunning = isClassifyRunning;
-    // A session is classified if we have classification results (from task metadata or classification.json file)
-    const isClassified = !!classificationInfo;
-    const isDisabled = isRunning || isClassified;
-
-    let title = 'Classify session';
-    if (isRunning) {
-      title = 'Classifying...';
-    } else if (isClassified) {
-      title = 'Already classified';
-    }
-
-    return (
-      <button
-        type="button"
-        className="activity-resume-button"
-        data-testid="classify-button"
-        title={title}
-        disabled={isDisabled}
-        onClick={(e) => {
-          e.stopPropagation();
-          if (!isDisabled) {
-            onSessionClassify?.(item);
-          }
-        }}
-      >
-        {isRunning ? (
-          <Loader2 className="h-4 w-4 animate-spin text-amber-500" />
-        ) : (
-          <ScanSearch className={`h-4 w-4${isClassified ? ' opacity-40' : ''}`} />
-        )}
-      </button>
-    );
-  }
 
   return (
     <div
@@ -194,10 +149,7 @@ function SessionRow({
         <span className="activity-name-text">
           {item.name.split('\n').find((l) => l.trim()) ?? item.name}
         </span>
-        {isClassifyRunning && (
-          <span className="activity-name-subtitle">Classifying...</span>
-        )}
-        {!isClassifyRunning && classificationInfo && (() => {
+        {classificationInfo && (() => {
           const isActing = isActionRunning || actingSessionId === item.sessionId;
 
           if (isActionComplete && actionArtifacts.length > 0) {
@@ -255,7 +207,7 @@ function SessionRow({
 
           return null;
         })()}
-        {!isClassifyRunning && !classificationInfo && item.subtitle && (
+        {!classificationInfo && item.subtitle && (
           <span className="activity-name-subtitle">{item.subtitle.split('\n').find((l) => l.trim()) ?? item.subtitle}</span>
         )}
         {renderEventIndicator(latestEvent, eventCount, item.sessionId ?? '', item.name, onOpenEventDialog)}
@@ -283,7 +235,6 @@ function SessionRow({
                 <CheckSquare className="h-4 w-4" />
               </button>
             )}
-            {item.type === 'claude_session' && onSessionClassify && renderClassifyButton()}
             <button
               type="button"
               className="activity-resume-button"
@@ -315,8 +266,6 @@ export interface ProjectActivityStripProps {
   onSessionResume?: (item: ProjectResourceListItem) => void;
   /** Open session tasks in lens viewer */
   onSessionTasks?: (item: ProjectResourceListItem) => void;
-  /** Run classification on the session */
-  onSessionClassify?: (item: ProjectResourceListItem) => void;
   /** Execute the action from a completed classification */
   onActAccordingToClassification?: (item: ProjectResourceListItem, command: string) => void;
   /** Map of session ID → event count for notification badges */
@@ -341,7 +290,6 @@ export function ProjectActivityStrip({
   onItemClick,
   onSessionResume,
   onSessionTasks,
-  onSessionClassify,
   onActAccordingToClassification,
   sessionEventCounts,
   snifferEvents,
@@ -371,12 +319,11 @@ export function ProjectActivityStrip({
       .slice(0, maxItems);
   }, [items, search, maxItems]);
 
-  // Build sessionId → classification/action Task lookups AND worker session IDs in a single pass.
+  // Build sessionId → classification/action Task lookups in a single pass.
   // Prefer the most recently updated task.
-  const { sessionClassificationMap, sessionActionMap, workerSessionIds } = useMemo(() => {
+  const { sessionClassificationMap, sessionActionMap } = useMemo(() => {
     const classMap = new Map<string, Task>();
     const actionMap = new Map<string, Task>();
-    const workers = new Set<string>();
 
     const upsert = (map: Map<string, Task>, sid: string, t: Task) => {
       const existing = map.get(sid);
@@ -386,16 +333,13 @@ export function ProjectActivityStrip({
     };
 
     for (const t of learningTasks) {
-      const wid = t.metadata?.workerSessionId;
-      if (typeof wid === 'string' && (isClassificationTask(t) || isActionTask(t))) workers.add(wid);
-
       const sid = t.metadata?.sessionId;
       if (typeof sid !== 'string') continue;
 
       if (isClassificationTask(t)) upsert(classMap, sid, t);
       if (isActionTask(t)) upsert(actionMap, sid, t);
     }
-    return { sessionClassificationMap: classMap, sessionActionMap: actionMap, workerSessionIds: workers };
+    return { sessionClassificationMap: classMap, sessionActionMap: actionMap };
   }, [learningTasks]);
 
   // Map each session ID to its most recent sniffer event
@@ -474,7 +418,6 @@ export function ProjectActivityStrip({
               item={item}
               classificationTask={item.sessionId ? sessionClassificationMap.get(item.sessionId) ?? null : null}
               actionTask={item.sessionId ? sessionActionMap.get(item.sessionId) ?? null : null}
-              isWorkerSession={!!item.sessionId && workerSessionIds.has(item.sessionId)}
               eventCount={item.sessionId ? (sessionEventCounts?.get(item.sessionId) ?? 0) : 0}
               latestEvent={item.sessionId ? (sessionLatestEvent.get(item.sessionId) ?? null) : null}
               isLoading={!!loadingSessionId && loadingSessionId === item.sessionId}
@@ -482,7 +425,6 @@ export function ProjectActivityStrip({
               onItemClick={onItemClick}
               onSessionResume={onSessionResume}
               onSessionTasks={onSessionTasks}
-              onSessionClassify={onSessionClassify}
               onActAccordingToClassification={onActAccordingToClassification}
               onOpenEventDialog={(sid, name) => {
                 setDialogSessionId(sid);

--- a/ui/src/hooks/use-system-tools.ts
+++ b/ui/src/hooks/use-system-tools.ts
@@ -1,10 +1,11 @@
 import { useCallback, useRef, useSyncExternalStore } from 'react';
-import { systemTools, SystemActivity, ActivityProgress, ScanInfo } from '@sdk';
+import { systemTools, SystemActivity, ActivityProgress, ScanInfo, LastScanResult } from '@sdk';
 
 export interface SystemToolsSnapshot {
   currentActivity: SystemActivity | null;
   activityProgress: ActivityProgress | null;
   scanInfo: ScanInfo | null;
+  lastScanResult: LastScanResult | null;
   busy: boolean;
 }
 
@@ -13,6 +14,7 @@ function buildSnapshot(): SystemToolsSnapshot {
     currentActivity: systemTools.currentActivity,
     activityProgress: systemTools.activityProgress,
     scanInfo: systemTools.scanInfo,
+    lastScanResult: systemTools.lastScanResult,
     busy: systemTools.currentActivity !== null,
   };
 }
@@ -22,6 +24,7 @@ function shallowEqual(a: SystemToolsSnapshot, b: SystemToolsSnapshot): boolean {
     a.currentActivity === b.currentActivity &&
     a.activityProgress === b.activityProgress &&
     a.scanInfo === b.scanInfo &&
+    a.lastScanResult === b.lastScanResult &&
     a.busy === b.busy
   );
 }

--- a/ui/src/pages/home-landing/HomeLanding.tsx
+++ b/ui/src/pages/home-landing/HomeLanding.tsx
@@ -18,7 +18,6 @@ import { useClaudeProjectList } from '@src/hooks/use-claude-projects';
 import { useHooksSniffer } from '@src/hooks/use-hooks-sniffer';
 import { useEventDrivenSessions } from '@src/hooks/use-event-driven-sessions';
 import { useProjects } from '@src/hooks/use-projects';
-import { useSessionClassify } from '@src/hooks/use-session-classify';
 import { useActAccordingToClassification } from '@src/hooks/use-act-according-to-classification';
 import { useResumeInTerminal } from '@src/hooks/use-resume-in-terminal';
 import { useForkInTerminal } from '@src/hooks/use-fork-in-terminal';
@@ -37,8 +36,9 @@ import type React from 'react';
 import { SearchFilters, SearchResult } from '@src/hooks/use-record-search';
 import { navigateToResult } from '@src/navigation/record-type-nav';
 import { InlineSearchResults } from './InlineSearchResults';
-import { Loader2, PackageSearch } from 'lucide-react';
+import { Loader2, PackageSearch, X, CheckCircle2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { LastScanResult } from '@sdk';
 
 const getSafeTimestamp = (value?: string | null): number => {
   if (!value) return 0;
@@ -120,9 +120,19 @@ export function HomeLanding() {
     [currentProject?.typeId, annotationsRefetch],
   );
 
-  const { busy, resetAndRescan, currentActivity, activityProgress, scanInfo } = useSystemTools();
+  const { busy, resetAndRescan, currentActivity, activityProgress, scanInfo, lastScanResult } = useSystemTools();
   const [progressOpen, setProgressOpen] = useState(false);
   const [showWelcome, setShowWelcome] = useState(false);
+  const [postScanResult, setPostScanResult] = useState<LastScanResult | null>(null);
+
+  // Detect scan completion: when lastScanResult changes to a new value, capture it for display
+  const prevLastScanResultRef = useRef<LastScanResult | null>(null);
+  useEffect(() => {
+    if (lastScanResult && lastScanResult !== prevLastScanResultRef.current) {
+      setPostScanResult(lastScanResult);
+    }
+    prevLastScanResultRef.current = lastScanResult;
+  }, [lastScanResult]);
 
   // Show welcome modal once per app session when scanInfo first arrives as never_indexed.
   useEffect(() => {
@@ -138,6 +148,8 @@ export function HomeLanding() {
   const [selectedResultIndex, setSelectedResultIndex] = useState(-1);
 
   useEffect(() => { setSelectedResultIndex(-1); }, [searchQuery]);
+  // Clear post-scan panel when user starts a real search
+  useEffect(() => { if (searchQuery.trim().length >= 2) setPostScanResult(null); }, [searchQuery]);
   const [showSessionInput, setShowSessionInput] = useState(false);
   const sessionInputRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -199,15 +211,6 @@ export function HomeLanding() {
     });
     return byPath?.encoded_name || null;
   }, [claudeProjects, currentProject, currentProjectPath]);
-
-  const { classifySession, classifyingSessionIds } = useSessionClassify({
-    onStarted: () => {
-      void taskRefetch();
-    },
-    onCompleted: () => {
-      void taskRefetch();
-    },
-  });
 
   const { actOnClassification, actingSessionId } = useActAccordingToClassification({
     onStarted: () => {
@@ -374,21 +377,6 @@ export function HomeLanding() {
     [navigation],
   );
 
-  const handleSessionClassify = useCallback(
-    async (resource: ProjectResourceListItem) => {
-      const cwd = resource.path || selectedClaudeProjectCwd;
-      if (!resource.sessionId || !cwd) {
-        toast({
-          title: 'Session unavailable',
-          description: 'No session ID or working directory found.',
-          variant: 'destructive',
-        });
-        return;
-      }
-      await classifySession(resource.sessionId, cwd);
-    },
-    [classifySession, toast, selectedClaudeProjectCwd],
-  );
 
   const handleActAccordingToClassification = useCallback(
     async (resource: ProjectResourceListItem, command: string) => {
@@ -544,6 +532,42 @@ export function HomeLanding() {
             )}
           </div>
 
+          {/* Post-scan results panel — shown after scan completes when user hasn't searched yet */}
+          {postScanResult && searchQuery.trim().length < 2 && (
+            <div className="w-full max-w-3xl self-center shrink-0">
+              <div className="flex flex-col rounded-lg border border-border bg-card overflow-hidden">
+                <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+                  <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    Scan & index complete — {postScanResult.grand_total.toLocaleString()} records found
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setPostScanResult(null)}
+                    className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+                {postScanResult.types.filter((t) => t.count > 0).length > 0 ? (
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 px-3 py-2">
+                    {postScanResult.types
+                      .filter((t) => t.count > 0)
+                      .sort((a, b) => b.count - a.count)
+                      .map((t) => (
+                        <span key={t.type} className="flex items-center gap-1 text-xs text-muted-foreground">
+                          <span className="font-mono text-foreground">{t.type.replace('claude_', '')}</span>
+                          <span className="tabular-nums">{t.count.toLocaleString()}</span>
+                        </span>
+                      ))}
+                  </div>
+                ) : (
+                  <p className="px-3 py-2 text-xs text-muted-foreground">No records found on disk.</p>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* Inline search results */}
           <div className="w-full max-w-3xl self-center min-h-0 flex-1 overflow-hidden">
             <InlineSearchResults
@@ -576,7 +600,6 @@ export function HomeLanding() {
             onItemClick={handleResourceClick}
             onSessionResume={handleSessionResume}
             onSessionTasks={handleSessionTasks}
-            onSessionClassify={(item) => void handleSessionClassify(item)}
             onActAccordingToClassification={(item, cmd) => void handleActAccordingToClassification(item, cmd)}
             actingSessionId={actingSessionId}
             sessionEventCounts={sessionEventCounts}


### PR DESCRIPTION
## Summary

- **Post-scan results panel**: After `resetAndRescan()` completes (scan + index both done), the homepage now immediately shows a compact panel with a per-type record count breakdown (e.g. `session 45 · hook 12 · skill 8`). The panel is dismissed when the user starts typing a search query or clicks ×.
- **Timing fix**: `lastScanResult` is set in the `finally` block of `resetAndRescan()` — after both scan and index phases — so the panel never appears while activity is still running.
- **Classify session button removed**: Simplified `SessionActionButtons` to only the Resume in terminal button; removed related props and logic from `ProjectActivityStrip` and `HomeLanding`.

## Changed files

- `ts_sdk/src/services/system-tools-service.ts` — added `LastScanResult` type and `lastScanResult` property; capture scan result after all phases in `resetAndRescan()`
- `ui/src/hooks/use-system-tools.ts` — expose `lastScanResult` in snapshot
- `ui/src/pages/home-landing/HomeLanding.tsx` — post-scan panel; removed classify session wiring
- `ui/src/components/live-workflow/SessionActionButtons.tsx` — removed classify button
- `ui/src/components/project-activity-strip/ProjectActivityStrip.tsx` — removed classify props and logic

## Test plan

- [ ] Reset index logs (`rm -f ~/.flow/schema/index_log.jsonl ~/.flow/schema/types/*/index_log.jsonl`), reload app — welcome modal appears
- [ ] Click "Let's go" — activity strip shows scan then index progress
- [ ] After both complete — post-scan panel appears with type counts and total
- [ ] Type 2+ chars in search bar — panel dismisses, inline search takes over
- [ ] Click × on panel — dismisses
- [ ] Session cards in activity strip no longer show classify button

🤖 Generated with [Claude Code](https://claude.com/claude-code)