### PR TITLE
Fix entity-to-record sync: create file on first save, fix Shell type mismatch

### DIFF
--- a/flow_sdk/core/entity/entity_model.py
+++ b/flow_sdk/core/entity/entity_model.py
@@ -242,7 +242,7 @@ class Entity(DBEntity):
             return None
         record = record_cls.discover_one(entity.id)
         if record is None:
-            return None
+            record = record_cls(id=entity.id)
         import asyncio
         try:
             await asyncio.to_thread(record.sync_from_entity, entity)

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -56,17 +56,20 @@ class TestEntityStore:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_store_returns_none_if_record_missing(self):
-        from flow_sdk.core.entity.entity_model import Entity
+    async def test_store_creates_record_if_missing(self, tmp_path):
+        """store() creates a new record on disk when none exists yet (e.g. Bookmark, Task)."""
+        from flow_sdk.fs_store.record import set_default_records_root, get_default_records_root
+        from flow_sdk.builtin.bookmark import Bookmark
+        from flow_sdk.fs_records.bookmark import BookmarkRecord  # noqa: F401 — triggers SchemaRegistry registration
 
-        entity = MagicMock(spec=Entity)
-        entity.get_type.return_value = "fake_store"
-        entity.id = "nonexistent-id"
+        old_root = get_default_records_root()
+        set_default_records_root(tmp_path)
+        try:
+            entity = Bookmark(id="bm-new-1", name="dog")
 
-        with (
-            patch.object(SchemaRegistry, "get_record_cls", return_value=FakeStoreRecord),
-            patch.object(FakeStoreRecord, "discover_one", return_value=None),
-        ):
-            result = await Entity._store(entity)
+            result = await entity._store()
 
-        assert result is None
+            assert result is not None
+            assert result.id == "bm-new-1"
+        finally:
+            set_default_records_root(old_root)


### PR DESCRIPTION
## Summary

- **Bookmark & Task now searchable**: `Entity._store()` previously returned `None` when no record file existed on disk, silently skipping file creation for DB-first entities. It now creates a new record file via `record_cls(id=entity.id)` on first save, so Bookmark and Task get filesystem records automatically and are included in the FTS5 search index.

- **Shell type rename (`shell_session` → `shell`)**: `ShellRecord._record_type` was `"shell_session"` but the `Shell` entity has `type="shell"`, causing `SchemaRegistry.get_record_cls("shell")` to return `None` and shell sync to silently fail. Renamed the record type, API action names, disk paths, DB references, TypeScript SDK, and all tests to use `"shell"` consistently. The old `"shell_session"` string no longer exists anywhere in the codebase.

- **Tests updated**: `test_store_returns_none_if_record_missing` replaced with `test_store_creates_record_if_missing` using a real `Bookmark` entity (no mocks) to verify the new create-on-first-save behavior.

## Test plan

- [ ] Run `python -m pytest tests/unit/ -v`
- [ ] Run `python -m pytest tests/api/ -v`
- [ ] Create a bookmark via UI, run rescan/reindex, search for its content — should appear in results
- [ ] Verify bootstrap still works (`GET /api/v1/graph/bootstrap` returns 200)
- [ ] Verify shell sessions still list correctly via `GET /api/v1/graph/shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)