### PR TITLE
Rename shell_session → shell across record type, API actions, and tests

### DIFF
--- a/flow_sdk/builtin/faas/compute_node.py
+++ b/flow_sdk/builtin/faas/compute_node.py
@@ -441,8 +441,8 @@ print(hashlib.sha256("|".join(parts).encode()).hexdigest())
     @action.post("terminal-command")
     async def terminal_command(self): return await self._pty_terminal_command()
 
-    @action.get(action_name="list-shell-sessions")
-    async def _list_shell_sessions(self): return await self._pty_list_shell_sessions()
+    @action.get(action_name="list-shells")
+    async def _list_shells(self): return await self._pty_list_shells()
 
     @action.get(action_name="session-transcript")
     async def _session_transcript(self): return await self._pty_session_transcript()
@@ -453,8 +453,8 @@ print(hashlib.sha256("|".join(parts).encode()).hexdigest())
     @action.post(action_name="reset-pty")
     async def reset_pty(self): return await self._pty_reset_pty()
 
-    @action.post(action_name="update-shell-session")
-    async def _update_shell_session(self): return await self._pty_update_shell_session()
+    @action.post(action_name="update-shell")
+    async def _update_shell(self): return await self._pty_update_shell()
 
     @action.post("ops")
     async def ops(self): return await self._ops_dispatch()
@@ -520,11 +520,11 @@ print(hashlib.sha256("|".join(parts).encode()).hexdigest())
     @action.all(action_name="fs-records", methods=["get", "post", "put", "delete"])
     async def fs_records_action(self): return await self._fs_records_action()
 
-    # -- shell session record actions --------------------------------------------
+    # -- shell record actions ----------------------------------------------------
 
-    @action.post(action_name="elevate-shell-session")
-    async def _elevate_shell_session(self) -> ApiResponse:
-        """Elevate a running shell session to a Claude session via AgenticProcess.open()."""
+    @action.post(action_name="elevate-shell")
+    async def _elevate_shell(self) -> ApiResponse:
+        """Elevate a running shell to a Claude session via AgenticProcess.open()."""
         from uuid import uuid4
 
         from flow_sdk.builtin.agentic_process import AgenticProcess

--- a/flow_sdk/builtin/faas/pty_actions.py
+++ b/flow_sdk/builtin/faas/pty_actions.py
@@ -435,8 +435,8 @@ class PtyActionsMixin:
             raise RuntimeError(f"PTY session not found after creation for shell {shell_id}")
         return pty
 
-    async def _pty_list_shell_sessions(self) -> ApiResponse:
-        """List active shell session entities (status != closed)."""
+    async def _pty_list_shells(self) -> ApiResponse:
+        """List active shell entities (status != closed)."""
         from flow_sdk.builtin.shell import Shell as ShellEntity
 
         all_sessions = await ShellEntity.get_all()
@@ -567,8 +567,8 @@ class PtyActionsMixin:
         logging.info("[reset_pty] Cleared %d session(s) for compute node %s", cleared, self.id)
         return ApiSuccessResponse(data={"cleared": cleared})
 
-    async def _pty_update_shell_session(self) -> ApiResponse:
-        """Update a shell session record's display properties.
+    async def _pty_update_shell(self) -> ApiResponse:
+        """Update a shell record's display properties.
 
         Accepts shell_id (required) and optional fields: tab_order (int),
         name (str). Updates the record on disk and returns

--- a/flow_sdk/db/drivers/sqlite/sqlite_driver.py
+++ b/flow_sdk/db/drivers/sqlite/sqlite_driver.py
@@ -140,8 +140,8 @@ def _parse_vfs_uri_to_ref(vfs_uri: str) -> tuple[str, str]:
     """Parse a VFS URI into a (type, id) tuple.
 
     Example:
-        ``"vfs://compute_node-@local/.../shell_session-@abc123"``
-        -> ``("shell_session", "abc123")``
+        ``"vfs://compute_node-@local/.../shell-@abc123"``
+        -> ``("shell", "abc123")``
 
     Extracts the last path segment matching ``{type}-@{id}``.
 

--- a/flow_sdk/fs_records/__init__.py
+++ b/flow_sdk/fs_records/__init__.py
@@ -48,8 +48,6 @@ from .schema_record import TypeIndexStatus as TypeIndexStatus
 from .session_analysis import SessionAnalysis as SessionAnalysis
 from .session_classification import SessionClassification as SessionClassification
 from .shell_record import ShellRecord as ShellRecord
-from .shell_record import ShellSessionRecord as ShellSessionRecord  # backward compat
-from .shell_record import ShellSessionStatus as ShellSessionStatus  # backward compat
 from .shell_record import ShellStatus as ShellStatus
 from .skill_record import SkillRecord as SkillRecord
 from .task import TaskResource as TaskResource

--- a/flow_sdk/fs_records/old_record_cleanup.py
+++ b/flow_sdk/fs_records/old_record_cleanup.py
@@ -93,7 +93,7 @@ async def cleanup_stale_skill_records() -> int:
 
 def run_old_record_cleanup() -> None:
     """Called once at startup in a background daemon thread."""
-    shell_deleted = _cleanup_records("shell_session", MAX_SHELL_RECORDS)
+    shell_deleted = _cleanup_records("shell", MAX_SHELL_RECORDS)
     ap_deleted = _cleanup_records("agentic_process", MAX_AGENTIC_RECORDS)
     if shell_deleted or ap_deleted:
         print(f"  Old record cleanup: removed {shell_deleted} shell + {ap_deleted} agentic_process records")

--- a/flow_sdk/fs_records/shell_record.py
+++ b/flow_sdk/fs_records/shell_record.py
@@ -1,9 +1,9 @@
-"""ShellRecord -- filesystem record for shell session persistence.
+"""ShellRecord -- filesystem record for shell persistence.
 
-Tracks the lifecycle of a shell session (PTY) across server restarts.
+Tracks the lifecycle of a shell (PTY) across server restarts.
 Each record represents a single shell tab and stores its PTY PID,
 working directory, visibility, and status. Records are stored globally
-at ~/.flow/records/shell_session/ and are used by PtySessionManager to
+at ~/.flow/records/shell/ and are used by PtySessionManager to
 recover running sessions after a server restart.
 """
 
@@ -27,10 +27,6 @@ class ShellStatus(StrEnum):
     CLOSED = "closed"
 
 
-# Backward-compat alias
-ShellSessionStatus = ShellStatus
-
-
 class ShellRecord(Record):
     """Filesystem record for a shell session.
 
@@ -39,7 +35,7 @@ class ShellRecord(Record):
     PtySessionManager which manages the in-memory PTY process state.
     """
 
-    _record_type: ClassVar[str] = RecordType.SHELL_SESSION
+    _record_type: ClassVar[str] = RecordType.SHELL
     index_fields: ClassVar[list[str]] = ["name"]
 
     def __init__(self, **kwargs: Any) -> None:
@@ -47,7 +43,7 @@ class ShellRecord(Record):
 
         if "id" not in kwargs:
             kwargs["id"] = str(_uuid.uuid4())
-        kwargs.setdefault("type", RecordType.SHELL_SESSION)
+        kwargs.setdefault("type", RecordType.SHELL)
         # Migrate old field names from pre-existing records on disk
         if "pty_session_id" in kwargs and "pty_pid" not in kwargs:
             kwargs["pty_pid"] = kwargs.pop("pty_session_id")
@@ -82,8 +78,8 @@ class ShellRecord(Record):
         pty_pid = getattr(self, "pty_pid", None) or getattr(self, "pty_session_id", None)
         if pty_pid is None:
             raise ValueError("No pty_pid set")
-        stem = record_stem("shell_session", self.id)
-        return get_default_records_root() / "shell_session" / stem / f"{pty_pid}.pty"
+        stem = record_stem("shell", self.id)
+        return get_default_records_root() / "shell" / stem / f"{pty_pid}.pty"
 
     @property
     def pty_stream_ref(self) -> "BinaryFsRef":
@@ -120,5 +116,3 @@ class ShellRecord(Record):
         return True
 
 
-# Backward-compat alias
-ShellSessionRecord = ShellRecord

--- a/flow_sdk/fs_store/record_types.py
+++ b/flow_sdk/fs_store/record_types.py
@@ -47,7 +47,7 @@ class RecordType(StrEnum):
     SESSION_CLASSIFICATION = "session_classification"
     ACTIVE_SESSIONS = "active_sessions"
     ACTIVE_SESSION = "active_session"
-    SHELL_SESSION = "shell_session"
+    SHELL = "shell"
     CLAUDE_DEBUG_LOG = "claude_debug_log"
     CLAUDE_ERROR = "claude_error"
 

--- a/tests/api/test_external_record_compat.py
+++ b/tests/api/test_external_record_compat.py
@@ -18,11 +18,11 @@ from flow_sdk.server.app import app
 
 
 @pytest.mark.asyncio
-async def test_shell_session_discover_no_meta(bootstrapped_client):
-    """_list_shell_sessions works correctly after _meta_data removal.
+async def test_shell_discover_no_meta(bootstrapped_client):
+    """list-shells works correctly after _meta_data removal.
 
     Creates a ShellRecord, discovers it, and verifies the
-    list-shell-sessions endpoint returns it without errors.
+    list-shells endpoint returns it without errors.
     """
     original_root = get_default_records_root()
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -51,7 +51,7 @@ async def test_shell_session_discover_no_meta(bootstrapped_client):
 
             # id and type stored in _data
             assert session.id == "test-session-1"
-            assert session.type == "shell_session"
+            assert session.type == "shell"
 
         finally:
             set_default_records_root(original_root)

--- a/tests/api/test_fts5_search.py
+++ b/tests/api/test_fts5_search.py
@@ -94,7 +94,7 @@ async def test_fts5_search_by_name(fts_driver):
 
 @pytest.mark.asyncio
 async def test_fts5_search_by_type(fts_driver):
-    """Entity.search('query', record_type='shell_session') filters by type."""
+    """Entity.search('query', record_type='shell') filters by type."""
     await _create_entity_with_content(
         fts_driver, "e1", "shell", "Session A", "matching query text"
     )

--- a/tests/api/test_pty_close_context.py
+++ b/tests/api/test_pty_close_context.py
@@ -1,7 +1,7 @@
 """Tests for PTY close over plain HTTP.
 
 After the fix, terminal-command/close works over plain HTTP (no WebSocket needed).
-It writes state=closed to the ShellRecord on disk so list-shell-sessions
+It writes state=closed to the ShellRecord on disk so list-shells
 excludes it — fixing the "close all → refresh → tabs back" bug.
 
 terminal-command/start still requires WebSocket context (it needs to stream PTY

--- a/tests/api/test_shell_lifecycle.py
+++ b/tests/api/test_shell_lifecycle.py
@@ -9,8 +9,8 @@ from flow_sdk.responses.response import ApiResponse
 
 
 @pytest.mark.asyncio
-async def test_create_shell_session_entity(bootstrapped_client):
-    """POST /graph/shell_session creates entity."""
+async def test_create_shell_entity(bootstrapped_client):
+    """POST /graph/shell creates entity."""
     response = await bootstrapped_client.post(
         "/api/v1/graph/shell",
         json={
@@ -33,8 +33,8 @@ async def test_create_shell_session_entity(bootstrapped_client):
 
 
 @pytest.mark.asyncio
-async def test_read_shell_session_entity(bootstrapped_client):
-    """GET /graph/shell_session/{id} returns entity."""
+async def test_read_shell_entity(bootstrapped_client):
+    """GET /graph/shell/{id} returns entity."""
     # Create first
     create_resp = await bootstrapped_client.post(
         "/api/v1/graph/shell",
@@ -54,8 +54,8 @@ async def test_read_shell_session_entity(bootstrapped_client):
 
 
 @pytest.mark.asyncio
-async def test_close_shell_session(bootstrapped_client):
-    """POST /graph/shell_session/{id}/close sets status=closed."""
+async def test_close_shell(bootstrapped_client):
+    """POST /graph/shell/{id}/close sets status=closed."""
     # Create entity
     create_resp = await bootstrapped_client.post(
         "/api/v1/graph/shell",
@@ -82,7 +82,7 @@ async def test_close_shell_session(bootstrapped_client):
 
 @pytest.mark.asyncio
 async def test_update_display(bootstrapped_client):
-    """POST /graph/shell_session/{id}/update-display updates fields."""
+    """POST /graph/shell/{id}/update-display updates fields."""
     # Create entity
     create_resp = await bootstrapped_client.post(
         "/api/v1/graph/shell",
@@ -105,8 +105,8 @@ async def test_update_display(bootstrapped_client):
 
 
 @pytest.mark.asyncio
-async def test_list_shell_sessions_entity_query(bootstrapped_client):
-    """list-shell-sessions returns only non-closed sessions via entity query."""
+async def test_list_shells_entity_query(bootstrapped_client):
+    """list-shells returns only non-closed sessions via entity query."""
     # Create two sessions with status="created" (not "running") to avoid zombie detection
     resp1 = await bootstrapped_client.post(
         "/api/v1/graph/shell",
@@ -121,7 +121,7 @@ async def test_list_shell_sessions_entity_query(bootstrapped_client):
 
     # List via compute_node action
     list_resp = await bootstrapped_client.get(
-        "/api/v1/graph/compute_node/@local/list-shell-sessions",
+        "/api/v1/graph/compute_node/@local/list-shells",
     )
     assert list_resp.status_code == 200, list_resp.text
     res = ApiResponse(**list_resp.json())
@@ -132,8 +132,8 @@ async def test_list_shell_sessions_entity_query(bootstrapped_client):
 
 
 @pytest.mark.asyncio
-async def test_close_shell_session_excluded_from_list(bootstrapped_client):
-    """Closed sessions don't appear in list-shell-sessions."""
+async def test_close_shell_excluded_from_list(bootstrapped_client):
+    """Closed sessions don't appear in list-shells."""
     # Create a session
     create_resp = await bootstrapped_client.post(
         "/api/v1/graph/shell",
@@ -150,7 +150,7 @@ async def test_close_shell_session_excluded_from_list(bootstrapped_client):
 
     # List should not include the closed session
     list_resp = await bootstrapped_client.get(
-        "/api/v1/graph/compute_node/@local/list-shell-sessions",
+        "/api/v1/graph/compute_node/@local/list-shells",
     )
     assert list_resp.status_code == 200
     res = ApiResponse(**list_resp.json())
@@ -180,7 +180,7 @@ async def test_close_all_then_list_empty(bootstrapped_client):
 
     # List should be empty (no running sessions)
     list_resp = await bootstrapped_client.get(
-        "/api/v1/graph/compute_node/@local/list-shell-sessions",
+        "/api/v1/graph/compute_node/@local/list-shells",
     )
     assert list_resp.status_code == 200
     res = ApiResponse(**list_resp.json())
@@ -216,7 +216,7 @@ async def test_create_shell_entity_fields(bootstrapped_client):
 
 @pytest.mark.asyncio
 async def test_run_command(bootstrapped_client):
-    """POST /graph/shell_session/{id}/run executes command and returns output."""
+    """POST /graph/shell/{id}/run executes command and returns output."""
     # Create entity
     create_resp = await bootstrapped_client.post(
         "/api/v1/graph/shell",
@@ -240,7 +240,7 @@ async def test_run_command(bootstrapped_client):
 
 @pytest.mark.asyncio
 async def test_set_env_persists_on_entity(bootstrapped_client):
-    """POST /graph/shell_session/{id}/set-env stores vars on the entity."""
+    """POST /graph/shell/{id}/set-env stores vars on the entity."""
     # Create entity
     create_resp = await bootstrapped_client.post(
         "/api/v1/graph/shell",

--- a/tests/long_tests/test_agentic_cli_shell_mix.py
+++ b/tests/long_tests/test_agentic_cli_shell_mix.py
@@ -15,7 +15,7 @@ Operations tested:
   merge   - Python port of useActiveTerminals logic
   start   - transition shell_A to running (PUT status + pty_pid)
   stop    - close shell_B (POST /close); verify entity deleted + excluded from
-            list-shell-sessions
+            list-shells
 """
 
 import pytest
@@ -230,13 +230,13 @@ async def test_agentic_cli_shell_mix(bootstrapped_client):
     assert tab_A_after["is_disabled"] is False
     assert tab_A_after["status"] == "running"
 
-    # list-shell-sessions includes shell_A (running, pty_pid set, not closed/error)
+    # list-shells includes shell_A (running, pty_pid set, not closed/error)
     list_r = await bootstrapped_client.get(
-        f"/api/v1/graph/compute_node/{cn_id}/list-shell-sessions"
+        f"/api/v1/graph/compute_node/{cn_id}/list-shells"
     )
     assert list_r.status_code == 200
     list_ids = {s["id"] for s in ApiResponse(**list_r.json()).data}
-    assert shell_A in list_ids, "Running shell_A must appear in list-shell-sessions"
+    assert shell_A in list_ids, "Running shell_A must appear in list-shells"
 
     # ── Stop: close shell_B ───────────────────────────────────────────────────
     r = await bootstrapped_client.post(f"/api/v1/graph/shell/{shell_B}/close")
@@ -252,10 +252,10 @@ async def test_agentic_cli_shell_mix(bootstrapped_client):
         "Closed shell_B should be deleted and not appear in tabs"
     )
 
-    # list-shell-sessions must NOT include closed shell_B
+    # list-shells must NOT include closed shell_B
     list_r2 = await bootstrapped_client.get(
-        f"/api/v1/graph/compute_node/{cn_id}/list-shell-sessions"
+        f"/api/v1/graph/compute_node/{cn_id}/list-shells"
     )
     assert list_r2.status_code == 200
     list_ids2 = {s["id"] for s in ApiResponse(**list_r2.json()).data}
-    assert shell_B not in list_ids2, "Closed shell_B must not appear in list-shell-sessions"
+    assert shell_B not in list_ids2, "Closed shell_B must not appear in list-shells"

--- a/tests/long_tests/test_shell_pty.py
+++ b/tests/long_tests/test_shell_pty.py
@@ -1,7 +1,7 @@
 """E2E test for Shell PTY lifecycle over WebSocket.
 
 Scenario:
-A. Create a shell → close it → must NOT appear in list-shell-sessions.
+A. Create a shell → close it → must NOT appear in list-shells.
 B. Create an idle shell → open WebSocket → call Shell.open() via rest_api_msg
    → PTY starts → SUCCESS response.
 C. Send "echo hello" via terminal-command/input rest_api_msg → receive
@@ -147,7 +147,7 @@ async def _recv(ws, timeout: float = 10.0) -> dict:
 @pytest.mark.timeout(90)
 async def test_shell_pty_e2e(pty_live_server):
     """
-    A. Create a shell → close it → not in list-shell-sessions.
+    A. Create a shell → close it → not in list-shells.
     B. Open WebSocket → call Shell.open() → PTY starts → SUCCESS.
     C. Send echo input → receive pty_output_msg → 'hello' in decoded output.
     """
@@ -159,7 +159,7 @@ async def test_shell_pty_e2e(pty_live_server):
         assert resp.status_code == 200, f"Bootstrap failed: {resp.text}"
         cn_id = resp.json()["data"]["default_compute_node"]["id"]
 
-        # ── A: Create a closed shell → must NOT appear in list-shell-sessions ──
+        # ── A: Create a closed shell → must NOT appear in list-shells ──
         r = await http.post(
             "/api/v1/graph/shell",
             json={"name": "closed-shell", "compute_node_id": cn_id},
@@ -171,12 +171,12 @@ async def test_shell_pty_e2e(pty_live_server):
         assert r.status_code == 200
 
         list_r = await http.get(
-            f"/api/v1/graph/compute_node/{cn_id}/list-shell-sessions"
+            f"/api/v1/graph/compute_node/{cn_id}/list-shells"
         )
         assert list_r.status_code == 200
         listed_ids = {s["id"] for s in list_r.json()["data"]}
         assert closed_id not in listed_ids, (
-            "Closed shell must not appear in list-shell-sessions"
+            "Closed shell must not appear in list-shells"
         )
 
         # ── B: Create idle shell → open WS → start PTY ───────────────────────

--- a/tests/unit/test_shell_domain.py
+++ b/tests/unit/test_shell_domain.py
@@ -70,7 +70,7 @@ def test_close_idempotent():
 
 def test_pty_stream_path(use_tmp_records_root):
     record = _make_record(id="sess-42", pty_pid="pty-xyz")
-    expected = use_tmp_records_root / "shell_session" / record_stem("shell_session", "sess-42") / "pty-xyz.pty"
+    expected = use_tmp_records_root / "shell" / record_stem("shell", "sess-42") / "pty-xyz.pty"
     assert record.pty_stream_path == expected
 
 

--- a/tests/unit/test_shell_lifecycle.py
+++ b/tests/unit/test_shell_lifecycle.py
@@ -98,7 +98,7 @@ async def test_close_session_transitions_record(session_manager, use_tmp_records
     mock_stream_file.delete.assert_called_once()
 
 
-def test_shell_session_entity_defaults():
+def test_shell_entity_defaults():
     """Shell entity has correct default fields."""
     from flow_sdk.builtin.shell import Shell
 
@@ -114,7 +114,7 @@ def test_shell_session_entity_defaults():
     assert entity.last_active_at is None
 
 
-def test_shell_session_entity_has_all_api_fields():
+def test_shell_entity_has_all_api_fields():
     """All expected fields are APIFields on Shell."""
     from flow_sdk.builtin.shell import Shell
 
@@ -178,7 +178,7 @@ def test_shell_record_entity_id_default():
     assert record.data.get("entity_id") is None
 
 
-def test_shell_session_status_default_idle():
+def test_shell_status_default_idle():
     """Shell entity default status is 'idle'."""
     from flow_sdk.builtin.shell import Shell
 
@@ -187,7 +187,7 @@ def test_shell_session_status_default_idle():
 
 
 @pytest.mark.asyncio
-async def test_shell_session_open_recovers_dead_running_session():
+async def test_shell_open_recovers_dead_running_session():
     """open() on a running shell with no live PTY spawns a new PTY (recovery path)."""
     from flow_sdk.builtin.shell import Shell
 

--- a/ts_sdk/src/entities/shell.ts
+++ b/ts_sdk/src/entities/shell.ts
@@ -64,8 +64,6 @@ export interface IShell extends IEntity {
   env?: Record<string, string> | null;
 }
 
-// Legacy alias
-export type IShellSession = IShell;
 
 @registerEntity
 export class Shell extends APIEntity<Shell> implements IShell {
@@ -490,7 +488,7 @@ export class Shell extends APIEntity<Shell> implements IShell {
   static async list(computeNodeId: string): Promise<Shell[]> {
     const { ComputeNode: ComputeNodeClass } = await import('./compute-node/compute-node');
     const action = new ActionInfo(
-      'list-shell-sessions',
+      'list-shells',
       ComputeNodeClass.type,
       computeNodeId,
       'GET',

--- a/ts_sdk/src/pty-sync/PtySyncSession.ts
+++ b/ts_sdk/src/pty-sync/PtySyncSession.ts
@@ -47,7 +47,7 @@ export class PtySyncSession {
    * Create the Phase-1 single segment covering the full session.
    * Call after initialize() once sessionStartTime is known.
    *
-   * @param sessionStartTime  ms epoch — from ShellSessionRecord.created_at
+   * @param sessionStartTime  ms epoch — from ShellRecord.created_at
    * @param rows              D = max(3, xterm.rows - 4)
    * @param baseAbsRow        evictionOffset at segment creation time
    */

--- a/ts_sdk/src/services/shell/index.ts
+++ b/ts_sdk/src/services/shell/index.ts
@@ -1,5 +1,5 @@
 export { TerminalType } from './builtInShells';
 export type { OpenTerminalOptions } from './openTerminal';
-export { Shell, type IShellSession, type IShell } from '../../entities/shell';
+export { Shell, type IShell } from '../../entities/shell';
 export { PtyConnection } from './ptyConnection';
 export { ptyOrphanBuffer } from './ptyOrphanBuffer';

--- a/ui/tests/api/shell_tabs.test.ts
+++ b/ui/tests/api/shell_tabs.test.ts
@@ -2,15 +2,15 @@
  * Shell Session Tab Write-Through Tests.
  *
  * Verifies the write-through cache architecture for Entity→Record sync:
- * - When a ShellSession entity is updated via PUT /graph/shell_session/<id>,
- *   the change is written through to the ShellSessionRecord on disk.
- * - After closing all tabs (status=closed), list-shell-sessions returns 0 tabs.
+ * - When a Shell entity is updated via PUT /graph/shell/<id>,
+ *   the change is written through to the ShellRecord on disk.
+ * - After closing all tabs (status=closed), list-shells returns 0 tabs.
  *
  * These tests reproduce the "close all → refresh → tabs back" bug scenario
  * and verify the fix.
  *
  * Test setup: uses the running backend at localhost:9007.
- * ShellSessionRecords are created on disk via the PTY start endpoint, then
+ * ShellRecords are created on disk via the PTY start endpoint, then
  * their status is updated via the graph API.
  */
 
@@ -19,9 +19,9 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
 import { apiTestSetup, get_local_compute_node, getTestSignupInfo } from '../utils/test-utils';
 
-/** Call list-shell-sessions via the REST API and return the records array. */
-async function listShellSessions(computeNodeId: string): Promise<any[]> {
-  const url = `${GRAPH_API_PREFIX}/${ComputeNode.type}/${computeNodeId}/list-shell-sessions`;
+/** Call list-shells via the REST API and return the records array. */
+async function listShells(computeNodeId: string): Promise<any[]> {
+  const url = `${GRAPH_API_PREFIX}/${ComputeNode.type}/${computeNodeId}/list-shells`;
   const response = await apiClient.get<any>(url);
   // apiClient unwraps ApiSuccessResponse — response is typically the data array
   if (Array.isArray(response)) return response;
@@ -29,16 +29,16 @@ async function listShellSessions(computeNodeId: string): Promise<any[]> {
   return Array.isArray(data) ? data : [];
 }
 
-/** Find a shell session by sessionId via list-shell-sessions. Returns null if not found. */
-async function getShellSession(computeNodeId: string, sessionId: string): Promise<any | null> {
-  // list-shell-sessions only returns active (non-closed) sessions.
+/** Find a shell session by sessionId via list-shells. Returns null if not found. */
+async function getShell(computeNodeId: string, sessionId: string): Promise<any | null> {
+  // list-shells only returns active (non-closed) sessions.
   // For closed session checks we scan the fs-records disk store directly.
-  const active = await listShellSessions(computeNodeId);
+  const active = await listShells(computeNodeId);
   const found = active.find((r: any) => r.pty_session_id === sessionId || r.id === sessionId);
   if (found) return found;
 
   // Check closed sessions via fs-records scan
-  const url = `${GRAPH_API_PREFIX}/${ComputeNode.type}/${computeNodeId}/fs-records/shell_session/${sessionId}`;
+  const url = `${GRAPH_API_PREFIX}/${ComputeNode.type}/${computeNodeId}/fs-records/shell/${sessionId}`;
   try {
     const response = await apiClient.get<any>(url);
     if (response && typeof response === 'object' && !Array.isArray(response)) {
@@ -53,7 +53,7 @@ async function getShellSession(computeNodeId: string, sessionId: string): Promis
 }
 
 /**
- * Create a ShellSessionRecord on disk by starting a PTY session.
+ * Create a ShellRecord on disk by starting a PTY session.
  * Returns the session_id used.
  */
 async function startPtySession(computeNodeId: string): Promise<string> {
@@ -79,7 +79,7 @@ async function closePtySession(computeNodeId: string, sessionId: string): Promis
   await apiClient.post(url, { shell_id: sessionId }).catch(() => {/* non-fatal if PTY not started */});
 }
 
-describe('shell_session_tabs', () => {
+describe('shell_tabs', () => {
   const info = getTestSignupInfo();
   let computeNode: ComputeNode;
 
@@ -89,12 +89,12 @@ describe('shell_session_tabs', () => {
     await computeNode.setup();
   });
 
-  it('test_list_shell_sessions_excludes_closed', async () => {
-    // Start a PTY session (creates ShellSessionRecord with state=running)
+  it('test_list_shells_excludes_closed', async () => {
+    // Start a PTY session (creates ShellRecord with state=running)
     const sessionId = await startPtySession(computeNode.id);
 
     // Verify it appears in list
-    const beforeClose = await listShellSessions(computeNode.id);
+    const beforeClose = await listShells(computeNode.id);
     const sessionInList = beforeClose.find((r: any) => r.pty_session_id === sessionId || r.id === sessionId);
     expect(sessionInList).toBeTruthy();
 
@@ -102,7 +102,7 @@ describe('shell_session_tabs', () => {
     await closePtySession(computeNode.id, sessionId);
 
     // After close, it should be excluded from the list
-    const afterClose = await listShellSessions(computeNode.id);
+    const afterClose = await listShells(computeNode.id);
     const sessionStillInList = afterClose.find((r: any) => r.pty_session_id === sessionId || r.id === sessionId);
     expect(sessionStillInList).toBeUndefined();
   }, 15000);
@@ -112,7 +112,7 @@ describe('shell_session_tabs', () => {
     const sessionId = await startPtySession(computeNode.id);
 
     // Verify record exists with running state
-    const before = await getShellSession(computeNode.id, sessionId);
+    const before = await getShell(computeNode.id, sessionId);
     expect(before).toBeTruthy();
     const beforeState = before?.state ?? before?.status;
     expect(beforeState).toBe('running');
@@ -122,7 +122,7 @@ describe('shell_session_tabs', () => {
 
     // Shell.close() deletes the disk record and the DB entity entirely —
     // so after close the session should no longer be discoverable.
-    const after = await getShellSession(computeNode.id, sessionId);
+    const after = await getShell(computeNode.id, sessionId);
     expect(after).toBeNull();
   }, 15000);
 
@@ -131,7 +131,7 @@ describe('shell_session_tabs', () => {
     const sessionId = await startPtySession(computeNode.id);
 
     // Simulate "page load" — list returns our session
-    const initialList = await listShellSessions(computeNode.id);
+    const initialList = await listShells(computeNode.id);
     const found = initialList.find((r: any) => r.pty_session_id === sessionId || r.id === sessionId);
     expect(found).toBeTruthy();
 
@@ -139,7 +139,7 @@ describe('shell_session_tabs', () => {
     await closePtySession(computeNode.id, sessionId);
 
     // Simulate "page refresh" — list should return 0 of our sessions
-    const afterRefresh = await listShellSessions(computeNode.id);
+    const afterRefresh = await listShells(computeNode.id);
     const stillFound = afterRefresh.find((r: any) => r.pty_session_id === sessionId || r.id === sessionId);
     expect(stillFound).toBeUndefined();
   }, 15000);
@@ -148,7 +148,7 @@ describe('shell_session_tabs', () => {
     // Starting a PTY session should produce a record with state=running
     const sessionId = await startPtySession(computeNode.id);
 
-    const record = await getShellSession(computeNode.id, sessionId);
+    const record = await getShell(computeNode.id, sessionId);
     expect(record).toBeTruthy();
     const state = record?.state ?? record?.status;
     expect(state).toBe('running');

--- a/ui/tests/api/test-shell-lifecycle.test.ts
+++ b/ui/tests/api/test-shell-lifecycle.test.ts
@@ -34,7 +34,7 @@ describe('Shell lifecycle (API)', () => {
     expect(closeBody.status).toBe('SUCCESS');
 
     // List
-    const listResp = await fetch(`${API}/compute_node/@local/list-shell-sessions`);
+    const listResp = await fetch(`${API}/compute_node/@local/list-shells`);
     const listBody = await listResp.json();
     const ids = (listBody.data || []).map((s: any) => s.id);
     expect(ids).not.toContain(created.id);
@@ -59,7 +59,7 @@ describe('Shell lifecycle (API)', () => {
     await fetch(`${API}/shell/${s2.data.id}/close`, { method: 'POST' });
 
     // List should be empty (for these sessions)
-    const listResp = await fetch(`${API}/compute_node/@local/list-shell-sessions`);
+    const listResp = await fetch(`${API}/compute_node/@local/list-shells`);
     const listBody = await listResp.json();
     const ids = (listBody.data || []).map((s: any) => s.id);
     expect(ids).not.toContain(s1.data.id);


### PR DESCRIPTION
## Summary

- Renames `RecordType.SHELL_SESSION` (`"shell_session"`) to `RecordType.SHELL` (`"shell"`) so the record type matches the entity type (`Shell.get_type() == "shell"`)
- `ShellRecord` now stores files under `records/shell/` instead of `records/shell_session/`
- API action names updated: `list-shell-sessions` → `list-shells`, `update-shell-session` → `update-shell`, `elevate-shell-session` → `elevate-shell`
- Removed `ShellSessionRecord` and `ShellSessionStatus` backward-compat aliases (unused)
- Removed `IShellSession` TS type alias (unused)
- Internal Python method names, test function names, test file names, and docstrings updated throughout

## Migration note for colleagues

Delete the old record folder after pulling:
```bash
rm -rf ~/.flow/records/shell_session/
```

## Test plan

- [x] Backend: 1959 passed, 0 new failures (`python -m pytest tests/unit/ tests/api/`)
- [x] Frontend unit: 800 passed (`npm run test:vitest:unit`)
- [ ] Frontend API test `test-shell-lifecycle` requires backend restart with new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)