### PR TITLE
Fix 'Open Session' crash for empty/new bookmark sessions

### DIFF
--- a/ts_sdk/src/agentic_processor/agentic-process.ts
+++ b/ts_sdk/src/agentic_processor/agentic-process.ts
@@ -351,8 +351,10 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
     const computeNode = dataContext.computeNode;
     if (!computeNode) throw new Error('[AgenticProcess.fromClaudeSession] No compute node');
 
-    // Resolve workdir from the session record on disk — required before upsert.
-    // If resume+workdir are already set on an existing process, skip disk discovery.
+    // Resolve workdir from the session record on disk.
+    // Best-effort: empty sessions have no JSONL yet, so cwd may be null.
+    // upsertSessionProcess is idempotent — if the process already exists it is
+    // returned immediately without needing workdir at all.
     let resolvedCwd = cwd;
     if (!resolvedCwd) {
       const { ClaudeSessionRecord } = await import(
@@ -362,14 +364,10 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
       resolvedCwd = record?.cwd ?? undefined;
     }
 
-    if (!resolvedCwd) {
-      throw new Error(`[AgenticProcess.fromClaudeSession] Cannot resolve workdir for session ${sessionId}`);
-    }
-
     // upsertSessionProcess is idempotent: finds existing process or creates a new one.
     // Backend sets cli_config.resume=true if the transcript exists on disk.
     const { processId } = await computeNode.upsertSessionProcess(sessionId, {
-      workdir: resolvedCwd,
+      ...(resolvedCwd ? { workdir: resolvedCwd } : {}),
       projectId: dataContext.project?.id,
     });
     const process = await AgenticProcess.getById(processId);

--- a/ui/src/components/terminal/interactive-terminal/InteractiveTerminal.tsx
+++ b/ui/src/components/terminal/interactive-terminal/InteractiveTerminal.tsx
@@ -412,6 +412,7 @@ const InteractiveTerminal: React.FC<InteractiveTerminalProps> = ({
       targetTimestamp,
       shellReady,
       ptySyncSnapshot.version,
+      process?.workdir ?? undefined,
     );
   const annotationElements = useMemo(
     () => traceFilters.promptAnnotations

--- a/ui/src/components/terminal/interactive-terminal/use-annotation-gutter.ts
+++ b/ui/src/components/terminal/interactive-terminal/use-annotation-gutter.ts
@@ -92,6 +92,7 @@ export function useAnnotationGutter(
   targetTimestamp?: string,
   replayComplete?: boolean,
   bufferVersion?: number,
+  workdir?: string,
 ) {
 
   const queryRequest = useMemo(
@@ -209,6 +210,7 @@ export function useAnnotationGutter(
       const bookmark = new Bookmark({
         bookmark_type: 'terminal_annotation',
         session_id: workerSessionId,
+        work_dir: workdir,
         data: { line: absoluteLine },
         content,
         title: 'Bookmark',
@@ -217,7 +219,7 @@ export function useAnnotationGutter(
       await bookmark.save([]);
       await refetch();
     },
-    [workerSessionId, refetch],
+    [workerSessionId, workdir, refetch],
   );
 
   const createComment = useCallback(

--- a/ui/src/pages/home-landing/HomeLanding.tsx
+++ b/ui/src/pages/home-landing/HomeLanding.tsx
@@ -418,7 +418,7 @@ export function HomeLanding() {
             onCloseBookmark={(m) => void closeBookmark(m)}
             onDeleteBookmark={(m) => void deleteBookmark(m)}
             onRemindBookmark={(m, mins) => void remindBookmark(m, mins)}
-            onOpenSession={(m) => m.session_id && resumeInTerminal(m.session_id, undefined, m.created_date ?? undefined)}
+            onOpenSession={(m) => m.session_id && resumeInTerminal(m.session_id, m.work_dir ?? undefined, m.created_date ?? undefined)}
             onForkSession={(m) => forkInTerminal(m.work_dir ?? undefined)}
             sessionEventCounts={sessionEventCounts}
             snifferEvents={snifferEvents}


### PR DESCRIPTION
## Summary
- Clicking "Open Session" on a bookmark crashed with `Cannot resolve workdir for session` when the session was new/empty (no prompts sent yet)
- Root cause: `fromClaudeSession` threw before even calling the backend, even though the backend handles missing `workdir` gracefully
- Also stores `work_dir` on bookmarks at creation time so future sessions can skip the JSONL disk lookup

## Changes
- **`agentic-process.ts`** — remove premature throw when `workdir` can't be resolved; pass it only if available
- **`use-annotation-gutter.ts`** — accept `workdir` param and store it on new bookmarks
- **`InteractiveTerminal.tsx`** — pass `process.workdir` down to the annotation gutter hook
- **`HomeLanding.tsx`** — pass `m.work_dir` from bookmark when opening a session

## Test plan
- [ ] Open a brand new terminal session (no prompts written)
- [ ] Add a bookmark in that session
- [ ] Go to the Bookmarks panel and click "Open Session" — should open without error
- [ ] Repeat with an existing session that has messages — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)