### PR TITLE
FLOWPAD-1821: Show session rename in search results

### DIFF
--- a/flow_sdk/builtin/agentic_process.py
+++ b/flow_sdk/builtin/agentic_process.py
@@ -432,12 +432,29 @@ async def _run_claude_subprocess(
             pass
 
 
-async def _index_session_on_close(worker_session_id: str) -> None:
-    """Index the ClaudeSessionRecord after an AgenticProcess closes (fire-and-forget)."""
+async def _index_session_on_close(worker_session_id: str, pty_title: str | None = None) -> None:
+    """Index the ClaudeSessionRecord after an AgenticProcess closes (fire-and-forget).
+
+    pty_title: Claude-generated tab title captured from ANSI OSC escapes in PTY
+               output.  Used as the FTS title / entity name when the JSONL has no
+               user-set custom-title (i.e. the user never ran /rename).
+    """
     try:
         from flow_sdk.fs_records.claude.claude_session import ClaudeSessionRecord
         record = ClaudeSessionRecord.discover_one(worker_session_id)
         if record:
+            # Inject PTY title when JSONL has no user-set custom-title.
+            if pty_title:
+                inst = object.__getattribute__(record, "__dict__")
+                if not inst.get("custom_title"):
+                    record.name = pty_title
+                    # Force FTS parse (to capture content), then override the title.
+                    _ = record.search_content  # populates _fts_cache
+                    cache = inst.get("_fts_cache")
+                    object.__setattr__(
+                        record, "_fts_cache",
+                        (pty_title[:120], cache[1] if cache else None),
+                    )
             await record.sync_to_db()
             logger.debug("[AgenticProcess] indexed session %s on close", worker_session_id)
     except Exception:
@@ -772,7 +789,18 @@ class AgenticProcess(Entity):
             await self.save()
 
             if self.worker_session_id:
-                asyncio.create_task(_index_session_on_close(self.worker_session_id))
+                # Read Claude-generated tab title from in-memory cache (populated
+                # by on_pty_output when ANSI OSC title escapes are detected).
+                # Must be read here — shell_id is still known and the title cache
+                # is populated regardless of whether the close is graceful.
+                _pty_title: str | None = None
+                if shell_id:
+                    try:
+                        from flow_sdk.builtin.faas.pty_actions import get_pty_session_title
+                        _pty_title = get_pty_session_title(shell_id)
+                    except Exception:
+                        pass
+                asyncio.create_task(_index_session_on_close(self.worker_session_id, pty_title=_pty_title))
 
             if shell_id:
                 from flow_sdk.builtin.shell import Shell

--- a/flow_sdk/builtin/faas/pty_actions.py
+++ b/flow_sdk/builtin/faas/pty_actions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import re as _re
 import uuid
 from typing import TYPE_CHECKING, Callable
 
@@ -26,6 +27,39 @@ if TYPE_CHECKING:
 # Prevents OS PTY device exhaustion (macOS default limit: 511).
 _PTY_CAP = 70
 _PTY_EVICT_COUNT = 10
+
+# ---------------------------------------------------------------------------
+# Session title tracking — captures Claude-generated tab titles in real time.
+# Keyed by shell_id (entity UUID).  Populated by on_pty_output() whenever an
+# ANSI OSC title escape is detected that isn't a Claude Code spinner frame.
+# ---------------------------------------------------------------------------
+_pty_session_titles: dict[str, str] = {}
+
+# Matches OSC 0 terminal title sequences: ESC ] 0 ; <title> BEL (or ST)
+_OSC_TITLE_RE = _re.compile(rb"\x1b\]0;([^\x07\x1b]+)(?:\x07|\x1b\\)")
+# Strips a leading spinner glyph + space (e.g. "✳ Morning coding session" → "Morning coding session")
+_SPINNER_PREFIX_RE = _re.compile(r"^[^\x00-\x7F] ")
+
+
+def _detect_osc_title(data: bytes) -> str | None:
+    """Extract the last meaningful session title from a raw PTY chunk, or None."""
+    matches = _OSC_TITLE_RE.findall(data)
+    for raw in reversed(matches):
+        try:
+            title = raw.decode("utf-8", errors="replace").strip()
+        except Exception:
+            continue
+        if "Claude Code" in title:
+            continue  # spinner-only frame ("⠂ Claude Code") — not a real title
+        title = _SPINNER_PREFIX_RE.sub("", title).strip()
+        if title:
+            return title
+    return None
+
+
+def get_pty_session_title(shell_id: str) -> str | None:
+    """Return the last Claude-generated title seen for *shell_id*, or None."""
+    return _pty_session_titles.get(shell_id)
 
 
 class PtyActionsMixin:
@@ -289,6 +323,12 @@ class PtyActionsMixin:
         def on_pty_output(data: bytes):
             logging.info(f"[PTY] on_pty_output (machine): {len(data)} bytes for session {shell_id}")
             current_pty_key = (self.id, self.node_provider_id, shell_id)
+
+            # Track Claude-generated session title (set via ANSI OSC escape after first prompt).
+            # Stored in module-level dict so AgenticProcess.close() can read it at close time.
+            _title = _detect_osc_title(data)
+            if _title and _pty_session_titles.get(shell_id) != _title:
+                _pty_session_titles[shell_id] = _title
 
             # Append to replay buffer (returns OutputChunk with seq and timestamp)
             chunk_record = replay_buffer.append(current_pty_key, data)

--- a/flow_sdk/builtin/shell.py
+++ b/flow_sdk/builtin/shell.py
@@ -55,6 +55,7 @@ class Shell(Entity):
     error_message: str | None = APIField(default=None, description="Error message when status=error")
     worker_pid: int | None = APIField(default=None, description="OS PID of the running worker process")
     worker_name: str | None = APIField(default=None, description="Worker executable name, e.g. 'claude'")
+    user_renamed: bool = APIField(default=False, description="True when user explicitly renamed this shell via /rename or the UI")
 
     _api_visible: ClassVar[bool] = True
 
@@ -474,15 +475,25 @@ class Shell(Entity):
     async def update_display(self) -> ApiResponse:
         """Update display properties (name, tab_order).
 
-        POST body: {name?, tab_order?}
+        POST body: {name?, tab_order?, is_pty?}
+
+        When ``is_pty=True`` the name came from a PTY OSC title escape (not a
+        user-initiated rename). If ``user_renamed`` is already True on this
+        entity the PTY name is ignored — the user's explicit rename wins.
         """
         request_info = get_current_request_info()
         body = await request_info.get_post_data() if request_info else {}
 
+        is_pty = bool(body.get("is_pty", False))
         changed = False
         if "name" in body:
-            self.name = body["name"]
-            changed = True
+            if is_pty and self.user_renamed:
+                pass  # PTY title must not override an explicit user rename
+            else:
+                self.name = body["name"]
+                if not is_pty:
+                    self.user_renamed = True
+                changed = True
         if "tab_order" in body:
             self.tab_order = body["tab_order"]
             changed = True

--- a/ui/src/components/terminal/TabbedTerminal.tsx
+++ b/ui/src/components/terminal/TabbedTerminal.tsx
@@ -371,13 +371,18 @@ const TabbedTerminal: React.FC<TabbedTerminalProps> = ({ className = '', addTabB
     // Guard: reject TypeId-formatted strings (e.g. "claude-<uuid>", "shell-<uuid>")
     if (/^[a-z][a-z0-9-]*-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(newName)) return;
 
-    void shell.updateDisplay({ name: newName });
+    // PTY title changes must not override an explicit user rename.
+    // user_renamed is set by the backend when the user runs /rename in CC or
+    // renames via the UI dialog.
+    if (!injectRename && shell.user_renamed) return;
+
+    void shell.updateDisplay({ name: newName, is_pty: !injectRename });
 
     // Rule 4: inject /rename for Claude processes — only when user-initiated,
     // never when the title came from xterm (PTY escape sequence), to avoid a loop
     // where Claude sets the title → we inject /rename → Claude sets the title again.
     if (injectRename && session.agenticProcess && shell.connected) {
-      void shell.sendInput(`/rename ${newName}\n`);
+      void shell.sendInput(`/rename ${newName}\r`);
     }
   };
 


### PR DESCRIPTION
## Summary
- Session renames (via `/rename`) now appear in search results — the custom title is indexed and shown on the search card
- PTY session title tracking added to `pty_actions.py` and `shell.py`
- `TabbedTerminal` updated to reflect renamed session titles

## Test plan
- [ ] Rename a Claude session with `/rename My Session`
- [ ] Search for the session — card should show the custom title

🤖 Generated with [Claude Code](https://claude.com/claude-code)