### PR TITLE
fix keychain read blocking event loop during bootstrap

### DIFF
--- a/flow_sdk/server/routes/bootstrap.py
+++ b/flow_sdk/server/routes/bootstrap.py
@@ -483,7 +483,7 @@ async def is_cloud_login_available() -> bool:
     """Check if cloud login is available by checking stored credentials."""
     try:
         from flow_sdk.cli.auth import is_logged_in
-        return is_logged_in()
+        return await asyncio.to_thread(is_logged_in)
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary
- `is_cloud_login_available()` was calling `keyring.get_password()` (via `is_logged_in()`) synchronously on the async event loop
- On macOS, this blocks waiting for the Keychain permission dialog — freezing the entire server
- Wrapped in `asyncio.to_thread()` so the event loop stays responsive while the dialog is open

## Root cause
On version upgrade, macOS requires re-authorization for Keychain access per binary. The blocking call caused a Network Error in the UI because the server couldn't respond to the bootstrap request while the dialog was waiting for user input.

## Test plan
- [ ] Downgrade to an older version, then upgrade — Keychain dialog appears but app stays responsive (no Network Error)
- [ ] Delete keychain entry (`security delete-generic-password -s "Flowpad.ai" -a "flowpad_api_key"`) and restart — bootstrap succeeds even while dialog is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)