### PR TITLE
Enable hooks in search results (FLOWPAD-1824)

### DIFF
--- a/flow_sdk/fs_records/claude/claude_hook_record.py
+++ b/flow_sdk/fs_records/claude/claude_hook_record.py
@@ -152,6 +152,25 @@ class ClaudeHookRecord(Record):
         return rec
 
     @classmethod
+    def discovery_items_count(cls, limit: int | None = None) -> int:
+        count = len(ClaudeHookRecordList())
+        return min(count, limit) if limit is not None else count
+
+    @classmethod
+    def discover_iter(cls, limit: int | None = None, scope: "Scope | None" = None, **kwargs: Any) -> Iterator[ClaudeHookRecord]:
+        rl = ClaudeHookRecordList(search_paths=kwargs.get("search_paths"))
+        count = 0
+        for rec in rl:
+            if scope is not None:
+                scope_val = scope.value if hasattr(scope, "value") else str(scope)
+                if _scope_str(rec.scope) != scope_val:
+                    continue
+            yield rec
+            count += 1
+            if limit is not None and count >= limit:
+                return
+
+    @classmethod
     def discover(
         cls,
         scope: Scope | None = None,

--- a/ui/src/components/record-search-bar/RecordSearchBar.tsx
+++ b/ui/src/components/record-search-bar/RecordSearchBar.tsx
@@ -5,7 +5,7 @@ import { cn } from '@src/lib/utils';
 import { CornerDownLeft, Search, SlidersHorizontal, X } from 'lucide-react';
 import { KeyboardEvent, useCallback, useRef, useState } from 'react';
 
-const RECORD_TYPES = ['bookmark', 'claude_session', 'skill', 'agent', 'hook', 'command'];
+const RECORD_TYPES = ['bookmark', 'claude_session', 'skill', 'agent', 'claude_hook', 'command'];
 const TIME_PRESETS = [
   { value: '1h', label: '1h' },
   { value: '1d', label: '1d' },


### PR DESCRIPTION
## Summary
- Add `discover_iter()` and `discovery_items_count()` to `ClaudeHookRecord` so the scan pipeline can find hooks in `settings.json` files
- Fix UI search filter: `hook` → `claude_hook` to match the actual record type in the DB

## Test plan
- [ ] Restart server, click "Refresh search data", verify hooks appear in scan results (28 hooks)
- [ ] Filter by `claude_hook` in the browse search bar — should list all hooks
- [ ] Search for a hook event name (e.g. "PreToolUse") — should return matching hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)