### PR TITLE
Add docs/plans/workflows to search; fix FTS content indexing and click navigation (FLOWPAD-1827)

### DIFF
--- a/flow_sdk/builtin/faas/fs_records_actions.py
+++ b/flow_sdk/builtin/faas/fs_records_actions.py
@@ -85,8 +85,8 @@ class FsRecordsActionsMixin:
                             "fts_description": getattr(ent, "_fts_description", None),
                             "status": ent_status,
                             "scope": getattr(ent, "scope", "") or "",
-                            "created_at": str(getattr(ent, "created_date", "") or ""),
-                            "modified_at": str(getattr(ent, "updated_date", "") or ""),
+                            "created_at": (d.isoformat() if (d := getattr(ent, "created_date", None)) else ""),
+                            "modified_at": (d.isoformat() if (d := getattr(ent, "updated_date", None)) else ""),
                             "source_path": self._resolve_source_path(ent),
                             "labels": getattr(ent, "labels", None) or [],
                         }
@@ -130,8 +130,8 @@ class FsRecordsActionsMixin:
                     "fts_description": getattr(ent, "_fts_description", None),
                     "status": ent_status,
                     "scope": getattr(ent, "scope", "") or "",
-                    "created_at": str(getattr(ent, "created_date", "") or ""),
-                    "modified_at": str(getattr(ent, "updated_date", "") or ""),
+                    "created_at": (d.isoformat() if (d := getattr(ent, "created_date", None)) else ""),
+                    "modified_at": (d.isoformat() if (d := getattr(ent, "updated_date", None)) else ""),
                     "source_path": self._resolve_source_path(ent),
                     "labels": getattr(ent, "labels", None) or [],
                 }

--- a/flow_sdk/fs_records/__init__.py
+++ b/flow_sdk/fs_records/__init__.py
@@ -13,6 +13,7 @@ from .agent_status import is_terminal as is_terminal
 from .agentic_process_record import AgenticProcessStatus as ProcessorStatus  # backward compat
 from .artifact import Artifact as Artifact
 from .markdown_record import MarkdownRecord as MarkdownRecord
+from . import asset_record as _asset_record  # noqa: F401 — trigger "asset" type_registry
 from .markdown_record import MarkdownRecord as AssetRecord  # noqa: F401 — backward compat alias
 from .annotation_record import AnnotationRecord as AnnotationRecord
 from .bookmark import BookmarkRecord as BookmarkRecord

--- a/flow_sdk/fs_records/claude/claude_plan.py
+++ b/flow_sdk/fs_records/claude/claude_plan.py
@@ -11,10 +11,34 @@ import uuid
 from pathlib import Path
 from typing import ClassVar, Iterator
 
+import os
 from flow_sdk.fs_store import Record, RecordType
 from flow_sdk.fs_store.fs_ref import FSRef
 
-_CLAUDE_PLANS_DIR = Path.home() / ".claude" / "plans"
+
+def _plan_search_dirs() -> list[Path]:
+    """Return directories to scan for plan .md files.
+
+    Scans user-level (~/.claude/plans), cwd/.claude/plans if present,
+    and any extra dirs from FLOWPAD_PLAN_DIRS (colon-separated).
+    """
+    dirs: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(p: Path) -> None:
+        rp = p.resolve()
+        if rp not in seen and rp.is_dir():
+            seen.add(rp)
+            dirs.append(p)
+
+    _add(Path.home() / ".claude" / "plans")
+    _add(Path(os.getcwd()) / ".claude" / "plans")
+
+    for extra in os.environ.get("FLOWPAD_PLAN_DIRS", "").split(":"):
+        if extra.strip():
+            _add(Path(extra.strip()))
+
+    return dirs
 
 
 def _extract_name_from_markdown(text: str) -> str | None:
@@ -112,20 +136,26 @@ class ClaudePlanRecord(Record):
 
     @classmethod
     def _external_source_iter(cls, limit: int | None = None) -> Iterator["ClaudePlanRecord"]:
-        if not _CLAUDE_PLANS_DIR.is_dir():
-            return
+        seen: set[str] = set()
         count = 0
-        for md_file in sorted(_CLAUDE_PLANS_DIR.glob("*.md")):
-            yield cls._from_md_file(md_file)
-            count += 1
-            if limit is not None and count >= limit:
-                return
+        for plans_dir in _plan_search_dirs():
+            for md_file in sorted(plans_dir.glob("*.md")):
+                key = str(md_file.resolve())
+                if key in seen:
+                    continue
+                seen.add(key)
+                yield cls._from_md_file(md_file)
+                count += 1
+                if limit is not None and count >= limit:
+                    return
 
     @classmethod
     def _external_source_count(cls, limit: int | None = None) -> int:
-        if not _CLAUDE_PLANS_DIR.is_dir():
-            return 0
-        count = sum(1 for _ in _CLAUDE_PLANS_DIR.glob("*.md"))
+        seen: set[str] = set()
+        for plans_dir in _plan_search_dirs():
+            for md_file in plans_dir.glob("*.md"):
+                seen.add(str(md_file.resolve()))
+        count = len(seen)
         return min(count, limit) if limit is not None else count
 
     @classmethod

--- a/flow_sdk/fs_records/markdown_record.py
+++ b/flow_sdk/fs_records/markdown_record.py
@@ -6,9 +6,11 @@ Supports discovery of .md files across a project directory.
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
-from typing import Any, ClassVar
+
+from typing import Any, ClassVar, Iterator
 
 from flow_sdk.fs_store import Record, RecordType
 
@@ -17,6 +19,32 @@ from ._frontmatter import (
     _extract_frontmatter,
     _yaml_load,
 )
+
+def _doc_search_dirs() -> list[Path]:
+    """Return directories to scan for doc .md files.
+
+    Scans user-level (~/.claude/docs), cwd/.claude/docs if present,
+    and any extra dirs from FLOWPAD_DOC_DIRS (colon-separated).
+    """
+    dirs: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(p: Path) -> None:
+        rp = p.resolve()
+        if rp not in seen and rp.is_dir():
+            seen.add(rp)
+            dirs.append(p)
+
+    _add(Path.home() / ".claude" / "docs")
+    _add(Path(os.getcwd()) / ".claude" / "docs")
+    _add(Path(os.getcwd()) / "docs")
+
+    for extra in os.environ.get("FLOWPAD_DOC_DIRS", "").split(":"):
+        if extra.strip():
+            _add(Path(extra.strip()))
+
+    return dirs
+
 
 # Map from directory name to asset_type
 _DIR_TO_ASSET_TYPE: dict[str, str] = {
@@ -156,12 +184,47 @@ class MarkdownRecord(Record):
 
     @property
     def search_content(self) -> str | None:
-        """Searchable text for FTS indexing: links (title/tags now in dedicated columns)."""
+        """Searchable text for FTS indexing: body text + wiki links."""
         parts: list[str] = []
+        ar = self.asset_ref
+        if ar is not None and ar.exists():
+            try:
+                body = _extract_body(Path(ar.path).read_text(encoding="utf-8"))
+                if body:
+                    parts.append(body)
+            except Exception:
+                pass
         links = getattr(self, "links", None) or []
         if links:
             parts.append(" ".join(str(l) for l in links))
         return " ".join(parts) if parts else None
+
+    @classmethod
+    def _external_source_count(cls, limit: int | None = None) -> int:
+        seen: set[str] = set()
+        for docs_dir in _doc_search_dirs():
+            for md_file in docs_dir.rglob("*.md"):
+                seen.add(str(md_file.resolve()))
+        count = len(seen)
+        return min(count, limit) if limit is not None else count
+
+    @classmethod
+    def _external_source_iter(cls, limit: int | None = None) -> Iterator["MarkdownRecord"]:
+        seen: set[str] = set()
+        count = 0
+        for docs_dir in _doc_search_dirs():
+            for md_file in sorted(docs_dir.rglob("*.md")):
+                key = str(md_file.resolve())
+                if key in seen:
+                    continue
+                seen.add(key)
+                try:
+                    yield cls.from_file(md_file)
+                    count += 1
+                    if limit is not None and count >= limit:
+                        return
+                except Exception:
+                    continue
 
     @classmethod
     def discover(cls, project_dir: str | Path = "", **kwargs) -> list["MarkdownRecord"]:

--- a/flow_sdk/fs_records/workflow_record.py
+++ b/flow_sdk/fs_records/workflow_record.py
@@ -7,10 +7,42 @@ Content is indexed for full-text search.
 
 from __future__ import annotations
 
+import os
+import uuid
 from pathlib import Path
-from typing import Any, ClassVar
+
+from typing import Any, ClassVar, Iterator
 
 from flow_sdk.fs_store import Record, RecordType
+
+
+def _workflow_search_dirs() -> list[Path]:
+    """Return directories to scan for workflow .md files.
+
+    Scans user-level (~/.claude/workflows), cwd/.claude/workflows if present,
+    and any extra dirs from FLOWPAD_WORKFLOW_DIRS (colon-separated).
+    """
+    dirs: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(p: Path) -> None:
+        rp = p.resolve()
+        if rp not in seen and rp.is_dir():
+            seen.add(rp)
+            dirs.append(p)
+
+    _add(Path.home() / ".claude" / "workflows")
+    _add(Path(os.getcwd()) / ".claude" / "workflows")
+
+    for extra in os.environ.get("FLOWPAD_WORKFLOW_DIRS", "").split(":"):
+        if extra.strip():
+            _add(Path(extra.strip()))
+
+    return dirs
+
+
+def _workflow_id(path: Path) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, str(path.resolve())))
 
 
 class WorkflowRecord(Record):
@@ -52,3 +84,31 @@ class WorkflowRecord(Record):
     def from_path(cls, path: Path | str) -> WorkflowRecord:
         """Load a WorkflowRecord from a .md file path."""
         return cls(file_path=path)
+
+    @classmethod
+    def _external_source_count(cls, limit: int | None = None) -> int:
+        seen: set[str] = set()
+        for workflows_dir in _workflow_search_dirs():
+            for md_file in workflows_dir.glob("*.md"):
+                seen.add(str(md_file.resolve()))
+        count = len(seen)
+        return min(count, limit) if limit is not None else count
+
+    @classmethod
+    def _external_source_iter(cls, limit: int | None = None) -> Iterator["WorkflowRecord"]:
+        seen: set[str] = set()
+        count = 0
+        for workflows_dir in _workflow_search_dirs():
+            for md_file in sorted(workflows_dir.glob("*.md")):
+                key = str(md_file.resolve())
+                if key in seen:
+                    continue
+                seen.add(key)
+                try:
+                    rec = cls(file_path=md_file, id=_workflow_id(md_file))
+                    yield rec
+                    count += 1
+                    if limit is not None and count >= limit:
+                        return
+                except Exception:
+                    continue

--- a/flow_sdk/server/run.py
+++ b/flow_sdk/server/run.py
@@ -127,8 +127,19 @@ def _register_project_asset_dirs() -> None:
     appended to FLOWPAD_SKILL_DIRS / FLOWPAD_AGENT_DIRS (colon-separated).
     """
     from pathlib import Path
-    cwd = Path.cwd()
-    for env_var, subdir in [("FLOWPAD_SKILL_DIRS", ".claude/skills"), ("FLOWPAD_AGENT_DIRS", ".claude/agents")]:
+    # Derive repo root from __file__ (flow_sdk/server/run.py → 3 levels up)
+    # This is reliable regardless of how/where the server is invoked.
+    # TODO find a better solution
+    cwd = Path(__file__).resolve().parent.parent.parent
+    candidates = [
+        ("FLOWPAD_SKILL_DIRS", ".claude/skills"),
+        ("FLOWPAD_AGENT_DIRS", ".claude/agents"),
+        ("FLOWPAD_DOC_DIRS", ".claude/docs"),
+        ("FLOWPAD_DOC_DIRS", "docs"),
+        ("FLOWPAD_PLAN_DIRS", ".claude/plans"),
+        ("FLOWPAD_WORKFLOW_DIRS", ".claude/workflows"),
+    ]
+    for env_var, subdir in candidates:
         candidate = cwd / subdir
         if candidate.is_dir():
             existing = os.environ.get(env_var, "")

--- a/ui/src/components/assets/editor/AssetEditorRouter.tsx
+++ b/ui/src/components/assets/editor/AssetEditorRouter.tsx
@@ -35,6 +35,9 @@ export function AssetEditorRouter({ pointer }: AssetEditorRouterProps) {
     case 'claude_rules':
     case 'agent':
     case 'command':
+    case 'plan':
+    case 'workflow':
+    case 'asset':
       return <MarkdownAssetEditor sourcePath={vfsPath} />;
     default:
       return (

--- a/ui/src/components/record-search-bar/RecordSearchBar.tsx
+++ b/ui/src/components/record-search-bar/RecordSearchBar.tsx
@@ -5,7 +5,11 @@ import { cn } from '@src/lib/utils';
 import { CornerDownLeft, Search, SlidersHorizontal, X } from 'lucide-react';
 import { KeyboardEvent, useCallback, useRef, useState } from 'react';
 
-const RECORD_TYPES = ['bookmark', 'claude_session', 'skill', 'agent', 'claude_hook', 'command'];
+const RECORD_TYPES = [
+  'bookmark', 'claude_session', 'skill', 'agent', 'claude_hook', 'command',
+  'annotation', 'comment', 'task', 'workflow', 'docs', 'plan',
+  'claude_md', 'claude_memory', 'claude_rules', 'project', 'asset',
+];
 const TIME_PRESETS = [
   { value: '1h', label: '1h' },
   { value: '1d', label: '1d' },
@@ -14,13 +18,29 @@ const TIME_PRESETS = [
 ] as const;
 const STATUSES = ['active', 'closed', 'archived'];
 
+const TYPE_DISPLAY_NAMES: Record<string, string> = {
+  claude_session: 'session',
+  claude_hook: 'hook',
+};
+
 const TYPE_COLORS: Record<string, string> = {
   bookmark: 'bg-violet-500/20 text-violet-700 dark:text-violet-300',
-  session: 'bg-blue-500/20 text-blue-700 dark:text-blue-300',
+  claude_session: 'bg-blue-500/20 text-blue-700 dark:text-blue-300',
   skill: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-300',
   agent: 'bg-amber-500/20 text-amber-700 dark:text-amber-300',
-  hook: 'bg-orange-500/20 text-orange-700 dark:text-orange-300',
+  claude_hook: 'bg-orange-500/20 text-orange-700 dark:text-orange-300',
   command: 'bg-rose-500/20 text-rose-700 dark:text-rose-300',
+  annotation: 'bg-sky-500/20 text-sky-700 dark:text-sky-300',
+  comment: 'bg-teal-500/20 text-teal-700 dark:text-teal-300',
+  task: 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-300',
+  workflow: 'bg-indigo-500/20 text-indigo-700 dark:text-indigo-300',
+  docs: 'bg-cyan-500/20 text-cyan-700 dark:text-cyan-300',
+  plan: 'bg-fuchsia-500/20 text-fuchsia-700 dark:text-fuchsia-300',
+  claude_md: 'bg-lime-500/20 text-lime-700 dark:text-lime-300',
+  claude_memory: 'bg-pink-500/20 text-pink-700 dark:text-pink-300',
+  claude_rules: 'bg-red-500/20 text-red-700 dark:text-red-300',
+  project: 'bg-purple-500/20 text-purple-700 dark:text-purple-300',
+  asset: 'bg-stone-500/20 text-stone-700 dark:text-stone-300',
 };
 
 interface RecordSearchBarProps {
@@ -193,7 +213,7 @@ export function RecordSearchBar({
                     : 'border border-border/50 bg-background text-muted-foreground hover:bg-muted hover:border-border',
                 )}
               >
-                {t}
+                {TYPE_DISPLAY_NAMES[t] ?? t}
                 {filters.record_type === t && ' ✕'}
               </button>
             ))}

--- a/ui/src/components/terminal/interactive-terminal/use-annotation-gutter.ts
+++ b/ui/src/components/terminal/interactive-terminal/use-annotation-gutter.ts
@@ -195,7 +195,8 @@ export function useAnnotationGutter(
     if (!replayComplete || !targetTimestamp || scrollFiredRef.current) return;
     if (!adapter || !terminalReady) return;
 
-    const targetBookmark = sessionBookmarks.find((m) => m.created_date === targetTimestamp);
+    const normalizeTs = (ts: unknown) => String(ts ?? '').replace('+00:00', 'Z');
+    const targetBookmark = sessionBookmarks.find((m) => normalizeTs(m.created_date) === normalizeTs(targetTimestamp));
     if (!targetBookmark) return;
 
     const absRow = targetBookmark.data?.line as number | undefined;

--- a/ui/src/navigation/record-type-nav.ts
+++ b/ui/src/navigation/record-type-nav.ts
@@ -75,7 +75,8 @@ export const RECORD_TYPE_NAV: Partial<Record<string, RecordTypeNav>> = {
     primaryAction: async (r, navigation) => {
       const sessionId = r.session_id;
       if (sessionId) {
-        await navigation.openClaudeSession(sessionId);
+        const p = await AgenticProcess.fromClaudeSession(sessionId);
+        navigation.openDockPointer(p.dockPointer, r.created_at ? { t: r.created_at } : undefined);
       }
     },
   },

--- a/ui/src/navigation/record-type-nav.ts
+++ b/ui/src/navigation/record-type-nav.ts
@@ -85,6 +85,49 @@ export const RECORD_TYPE_NAV: Partial<Record<string, RecordTypeNav>> = {
       ? new DockPointer(ViewType.ASSETS, `editor/command/${r.source_path.replace(/^\//, '')}`)
       : null,
   },
+  comment: {
+    primaryAction: async (r, navigation) => {
+      const sessionId = r.session_id;
+      if (sessionId) {
+        await navigation.openClaudeSession(sessionId);
+      }
+    },
+  },
+  docs: {
+    dockPointer: (r) => r.source_path
+      ? new DockPointer(ViewType.ASSETS, `editor/docs/${r.source_path.replace(/^\//, '')}`)
+      : null,
+  },
+  plan: {
+    dockPointer: (r) => r.source_path
+      ? new DockPointer(ViewType.ASSETS, `editor/plan/${r.source_path.replace(/^\//, '')}`)
+      : null,
+  },
+  workflow: {
+    dockPointer: (r) => r.source_path
+      ? new DockPointer(ViewType.ASSETS, `editor/workflow/${r.source_path.replace(/^\//, '')}`)
+      : null,
+  },
+  claude_md: {
+    dockPointer: (r) => r.source_path
+      ? new DockPointer(ViewType.ASSETS, `editor/claude_md/${r.source_path.replace(/^\//, '')}`)
+      : null,
+  },
+  claude_memory: {
+    dockPointer: (r) => r.source_path
+      ? new DockPointer(ViewType.ASSETS, `editor/claude_memory/${r.source_path.replace(/^\//, '')}`)
+      : null,
+  },
+  claude_rules: {
+    dockPointer: (r) => r.source_path
+      ? new DockPointer(ViewType.ASSETS, `editor/claude_rules/${r.source_path.replace(/^\//, '')}`)
+      : null,
+  },
+  asset: {
+    dockPointer: (r) => r.source_path
+      ? new DockPointer(ViewType.ASSETS, `editor/asset/${r.source_path.replace(/^\//, '')}`)
+      : null,
+  },
   claude_settings: {
     dockPointer: () => DockPointer.forSettings(),
   },


### PR DESCRIPTION
## Summary

- **Search bar**: Expanded to show all 17 searchable types; added display name overrides (`claude_hook` → hook, `claude_session` → session)
- **Multi-location scan**: Added 3-location scanning (user-level `~/.claude/<type>`, cwd-level `.claude/<type>`, env var) to docs, plans, and workflows — matching the existing skills/agents pattern. Also added `<cwd>/docs` as a scan location for docs
- **FTS content indexing**: Fixed `MarkdownRecord.search_content` to include the document body text — previously only wiki links were indexed, so searching by content text returned no results
- **Progress counter**: Fixed scan progress showing X/16 instead of X/17 by importing `asset_record` to trigger its type registration
- **Click navigation**: Added `RECORD_TYPE_NAV` entries for docs, plans, workflows, claude_md, claude_memory, claude_rules, asset, and comment — all previously unclickable in search results
- **Docs navigation fix**: Changed docs click to open `DocsAssetEditor` via `ViewType.ASSETS` (uses ComputeNode VFS for arbitrary filesystem paths) instead of `DocsViewer` which crashed without an AgenticProcess context
- **Server startup**: Register repo-root dirs for docs/plans/workflows via env vars at startup, fixing cwd-unreliability at scan time

## Test plan

- [ ] Run scan — progress should show X/17 (not X/16)
- [ ] Search for text inside a doc file — result should appear (FTS body indexing)
- [ ] Search by doc filename — result should appear and be clickable (opens DocsAssetEditor)
- [ ] Search for plans, workflows, skills, agents — results clickable and open correct editor
- [ ] Search for claude_md, claude_memory, claude_rules — results clickable
- [ ] Search for sessions/hooks — display names show "session"/"hook" not "claude_session"/"claude_hook"
- [ ] All 17 type filter chips visible in search bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)