### PR TITLE
Scan all Claude-known projects for docs/plans/workflows/skills/agents (FLOWPAD-1827)

### DIFF
--- a/flow_sdk/builtin/api_key.py
+++ b/flow_sdk/builtin/api_key.py
@@ -275,7 +275,7 @@ class ApiKey(Entity):
         machine_hash = api_key_hash(raw_machine_id)
         return machine_hash in self.allowed_machine_id_hashes
 
-    async def save(self, someone_typeid: TypeId | None = None):
+    async def save(self, someone_typeid: TypeId | None = None, notify: bool = True):
         """
         Save API key and invalidate caches.
 
@@ -290,7 +290,7 @@ class ApiKey(Entity):
             Saved ApiKey entity
         """
         # Call parent save
-        result = await super().save(someone_typeid)
+        result = await super().save(someone_typeid, notify=notify)
 
         # Invalidate entity cache so fresh version is loaded on next access
         from flow_sdk.core.cache.entity_cache import entity_cache

--- a/flow_sdk/builtin/faas/web_domain.py
+++ b/flow_sdk/builtin/faas/web_domain.py
@@ -28,7 +28,7 @@ class WebDomain(Entity):
     async def get_by_domain(cls, domain: str) -> Optional["WebDomain"]:
         return await cls.get_one({"domain": domain})
 
-    async def save(self: "EntityType", owner: DBEntity | TypeId | types.NoneType = None) -> "EntityType":
+    async def save(self: "EntityType", owner: DBEntity | TypeId | types.NoneType = None, notify: bool = True) -> "EntityType":
         """
         Auto-verify domains ending with app_domain.
         If the domain ends with the configured app_domain, automatically set verified=True.
@@ -43,4 +43,4 @@ class WebDomain(Entity):
                 self.verified = True
                 service_log.info(f"Auto-verifying WebDomain: {self.domain} (matches app_domain: {micro_app_domain})")
 
-        return await super().save(owner)
+        return await super().save(owner, notify=notify)

--- a/flow_sdk/builtin/mention.py
+++ b/flow_sdk/builtin/mention.py
@@ -37,7 +37,7 @@ class Mention(Entity):
         )
         return await cls.get_all(entities_filter=_filter)
 
-    async def save(self, owner: Union[Entity, TypeId, None] = None) -> Mention:
+    async def save(self, owner: Union[Entity, TypeId, None] = None, notify: bool = True) -> Mention:
         mentioned_in = await Entity.get_by_typeid(
             TypeId(type=self.mentioned_in_entity_type, id=self.mentioned_in_entity_id)
         )
@@ -54,4 +54,4 @@ class Mention(Entity):
                 status_code=400,
                 detail=f"{self.mentioned_user_id} is not a member in {self.mentioned_in_entity_type}",
             )
-        return await super().save(owner)
+        return await super().save(owner, notify=notify)

--- a/flow_sdk/builtin/workspace.py
+++ b/flow_sdk/builtin/workspace.py
@@ -16,8 +16,8 @@ class Workspace(Entity):
     name: str = APIField()
     _api_visible: ClassVar[bool] = True
 
-    async def save(self: EntityType, owner: DBEntity | TypeId | types.NoneType = None) -> EntityType:
-        save_result = await super().save(owner)
+    async def save(self: EntityType, owner: DBEntity | TypeId | types.NoneType = None, notify: bool = True) -> EntityType:
+        save_result = await super().save(owner, notify=notify)
         # TODO consider moving this to a separate action from client side
         await self.grant_access_to_public_data()
         return save_result

--- a/flow_sdk/core/entity/entity_model.py
+++ b/flow_sdk/core/entity/entity_model.py
@@ -138,7 +138,7 @@ class Entity(DBEntity):
         return str(_uuid.uuid4())
 
     @classmethod
-    async def from_record(cls, record: "Record") -> Entity:
+    async def from_record(cls, record: "Record", notify: bool = True) -> Entity:
         """Create or update an Entity from a Record's meta_dict()."""
         record_type = record.type or record._record_type
         entity_cls = SchemaRegistry.get_entity_cls(record_type) or cls
@@ -199,7 +199,7 @@ class Entity(DBEntity):
                         setattr(entity, prop_name, record.get_prop(prop_name))
                     except Exception:
                         pass
-        await entity.save()
+        await entity.save(notify=notify)
         return entity
 
     async def _fts_upsert(self, type_name: str, content: str) -> None:
@@ -501,7 +501,7 @@ class Entity(DBEntity):
         await blob_index_entity.save(self.embedded_storage)
         # logging.info(f"Saved blob index for {self.typeid} with fields: {blob_index_entity._blob_index.fields.keys()} on \n {self.storage.vfs_root_path}")
 
-    async def save(self: EntityType, owner: DBEntity | TypeId | types.NoneType = None) -> EntityType:
+    async def save(self: EntityType, owner: DBEntity | TypeId | types.NoneType = None, notify: bool = True) -> EntityType:
         user_id = owner
         if isinstance(owner, Entity):
             user_id = owner.typeid
@@ -509,7 +509,7 @@ class Entity(DBEntity):
             if self.get_type() == BuiltinEntityType.USER.value:
                 user_id = self.typeid
         await self._save_blobs()
-        await super().save(user_id)
+        await super().save(user_id, notify=notify)
         # Sync entity metadata down to its record on disk
         await self._store()
         # Invalidate authorization cache since entity properties have changed

--- a/flow_sdk/db/db_entity.py
+++ b/flow_sdk/db/db_entity.py
@@ -370,7 +370,7 @@ class DBEntity(DBBaseRecord):
             owner = owner.typeid
         return await self._db.create(self, owner)
 
-    async def save(self: DBEntityType, owner: Union[DBEntity, TypeId, None] = None) -> DBEntityType:
+    async def save(self: DBEntityType, owner: Union[DBEntity, TypeId, None] = None, notify: bool = True) -> DBEntityType:
         if isinstance(owner, DBEntity):
             owner = owner.typeid
 
@@ -384,13 +384,14 @@ class DBEntity(DBBaseRecord):
             await self._db.update(self, owner)
 
         # Must notify after the entity is saved to the DB and the children are saved
-        if notify_created:
-            op = OperationType.CREATE
-        else:
-            op = OperationType.UPDATE
-        self_op = DataOpMessage(data=self, op=op, to_entity=self.typeid)
-        await self.add_entity_op_notification(self_op)
-        self._notify_observers(self_op)
+        if notify:
+            if notify_created:
+                op = OperationType.CREATE
+            else:
+                op = OperationType.UPDATE
+            self_op = DataOpMessage(data=self, op=op, to_entity=self.typeid)
+            await self.add_entity_op_notification(self_op)
+            self._notify_observers(self_op)
         self._dirty = False
 
         return self

--- a/flow_sdk/fs_records/_claude_projects.py
+++ b/flow_sdk/fs_records/_claude_projects.py
@@ -1,0 +1,77 @@
+"""Shared helper for resolving real filesystem paths of Claude-tracked projects.
+
+Claude stores per-project data in ~/.claude/projects/<encoded>/ where <encoded>
+is the project path with '/' replaced by '-'. This encoding is ambiguous for
+paths containing hyphens (e.g. /Users/foo/my-app → -Users-foo-my-app, which
+decodes incorrectly to /Users/foo/my/app).
+
+The reliable fix: read the 'cwd' field from a session JSONL file inside the
+project directory, which stores the original unencoded path.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterator
+
+
+_CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
+
+
+def _real_path_from_jsonl(project_dir: Path) -> Path | None:
+    """Return the real project path by reading 'cwd' from a session JSONL file.
+
+    Only reads the first JSONL file found and at most the first 50 lines —
+    cwd appears near the top of any active session file.
+    """
+    jsonl_files = sorted(project_dir.glob("*.jsonl"))
+    if not jsonl_files:
+        return None
+    try:
+        with jsonl_files[0].open(encoding="utf-8", errors="replace") as f:
+            for i, line in enumerate(f):
+                if i >= 50:
+                    break
+                if '"cwd"' not in line:
+                    continue
+                try:
+                    data = json.loads(line)
+                    cwd = data.get("cwd")
+                    if cwd and isinstance(cwd, str):
+                        return Path(cwd)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+    except OSError:
+        pass
+    return None
+
+
+def iter_claude_project_paths() -> Iterator[Path]:
+    """Yield the real filesystem path for each known Claude project.
+
+    Uses 'cwd' from session JSONL files as the authoritative source.
+    Falls back to the encoded-name decode for projects with no JSONL files
+    (e.g. brand-new projects or memory-only entries).
+    Only yields paths that exist on disk.
+    """
+    if not _CLAUDE_PROJECTS.is_dir():
+        return
+
+    seen: set[Path] = set()
+    for project_dir in sorted(_CLAUDE_PROJECTS.iterdir()):
+        if not project_dir.is_dir():
+            continue
+
+        real = _real_path_from_jsonl(project_dir)
+        if real is None:
+            # Fallback: decode encoded name (correct for paths without hyphens)
+            encoded = project_dir.name
+            real = Path("/" + encoded.lstrip("-").replace("-", "/"))
+
+        rp = real.resolve()
+        if rp in seen:
+            continue
+        if not real.is_dir():
+            continue
+        seen.add(rp)
+        yield real

--- a/flow_sdk/fs_records/agent_record.py
+++ b/flow_sdk/fs_records/agent_record.py
@@ -22,8 +22,9 @@ from flow_sdk.fs_store.record import Scope, _META_JSON
 def _agent_search_dirs() -> list[Path]:
     """Return directories to scan for agent .md files.
 
-    Scans user-level (~/.claude/agents) and the cwd/.claude/agents if present
-    (covers project-level agents when the server runs from the project dir).
+    Scans user-level (~/.claude/agents), all known Claude projects
+    (<project>/.claude/agents), cwd-level, and any extra dirs from
+    FLOWPAD_AGENT_DIRS (colon-separated).
     """
     import os
     dirs: list[Path] = []
@@ -36,6 +37,11 @@ def _agent_search_dirs() -> list[Path]:
             dirs.append(p)
 
     _add(Path.home() / ".claude" / "agents")
+
+    from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+    for real in iter_claude_project_paths():
+        _add(real / ".claude" / "agents")
+
     _add(Path(os.getcwd()) / ".claude" / "agents")
 
     for extra in os.environ.get("FLOWPAD_AGENT_DIRS", "").split(":"):

--- a/flow_sdk/fs_records/claude/claude_claude_md.py
+++ b/flow_sdk/fs_records/claude/claude_claude_md.py
@@ -74,13 +74,8 @@ class ClaudeMdFsRecord(Record):
                     return
 
         # Project-level CLAUDE.md files
-        if not _CLAUDE_PROJECTS.is_dir():
-            return
-        for project_dir in sorted(_CLAUDE_PROJECTS.iterdir()):
-            if not project_dir.is_dir():
-                continue
-            encoded = project_dir.name
-            real_path = Path("/" + encoded.lstrip("-").replace("-", "/"))
+        from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+        for real_path in iter_claude_project_paths():
             for rel in ("CLAUDE.md", ".claude/CLAUDE.md", "CLAUDE.local.md"):
                 candidate = real_path / rel
                 if candidate.is_file():
@@ -95,15 +90,11 @@ class ClaudeMdFsRecord(Record):
         for name in ("CLAUDE.md", "CLAUDE.local.md"):
             if (_CLAUDE_HOME / name).is_file():
                 count += 1
-        if _CLAUDE_PROJECTS.is_dir():
-            for project_dir in _CLAUDE_PROJECTS.iterdir():
-                if not project_dir.is_dir():
-                    continue
-                encoded = project_dir.name
-                real_path = Path("/" + encoded.lstrip("-").replace("-", "/"))
-                for rel in ("CLAUDE.md", ".claude/CLAUDE.md", "CLAUDE.local.md"):
-                    if (real_path / rel).is_file():
-                        count += 1
+        from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+        for real_path in iter_claude_project_paths():
+            for rel in ("CLAUDE.md", ".claude/CLAUDE.md", "CLAUDE.local.md"):
+                if (real_path / rel).is_file():
+                    count += 1
         return min(count, limit) if limit is not None else count
 
     @classmethod

--- a/flow_sdk/fs_records/claude/claude_memory.py
+++ b/flow_sdk/fs_records/claude/claude_memory.py
@@ -62,6 +62,7 @@ class ClaudeMemoryRecord(Record):
     ) -> Iterator["ClaudeMemoryRecord"]:
         if not _CLAUDE_PROJECTS.is_dir():
             return
+        from flow_sdk.fs_records._claude_projects import _real_path_from_jsonl
         count = 0
         for project_dir in sorted(_CLAUDE_PROJECTS.iterdir()):
             if not project_dir.is_dir():
@@ -70,7 +71,8 @@ class ClaudeMemoryRecord(Record):
             if not mem_dir.is_dir():
                 continue
             encoded = project_dir.name
-            real = "/" + encoded.lstrip("-").replace("-", "/")
+            real_path = _real_path_from_jsonl(project_dir)
+            real = str(real_path) if real_path else "/" + encoded.lstrip("-").replace("-", "/")
             for md_file in sorted(mem_dir.glob("*.md")):
                 yield cls._from_md_file(md_file, project_path=real, project_encoded=encoded)
                 count += 1

--- a/flow_sdk/fs_records/claude/claude_plan.py
+++ b/flow_sdk/fs_records/claude/claude_plan.py
@@ -19,8 +19,9 @@ from flow_sdk.fs_store.fs_ref import FSRef
 def _plan_search_dirs() -> list[Path]:
     """Return directories to scan for plan .md files.
 
-    Scans user-level (~/.claude/plans), cwd/.claude/plans if present,
-    and any extra dirs from FLOWPAD_PLAN_DIRS (colon-separated).
+    Scans user-level (~/.claude/plans), all known Claude projects
+    (<project>/.claude/plans), cwd-level, and any extra dirs from
+    FLOWPAD_PLAN_DIRS (colon-separated).
     """
     dirs: list[Path] = []
     seen: set[Path] = set()
@@ -32,6 +33,11 @@ def _plan_search_dirs() -> list[Path]:
             dirs.append(p)
 
     _add(Path.home() / ".claude" / "plans")
+
+    from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+    for real in iter_claude_project_paths():
+        _add(real / ".claude" / "plans")
+
     _add(Path(os.getcwd()) / ".claude" / "plans")
 
     for extra in os.environ.get("FLOWPAD_PLAN_DIRS", "").split(":"):

--- a/flow_sdk/fs_records/claude/claude_rules.py
+++ b/flow_sdk/fs_records/claude/claude_rules.py
@@ -73,13 +73,8 @@ class ClaudeRulesRecord(Record):
                     return
 
         # Project-level rules: <real_project>/.claude/rules/*.md
-        if not _CLAUDE_PROJECTS.is_dir():
-            return
-        for project_dir in sorted(_CLAUDE_PROJECTS.iterdir()):
-            if not project_dir.is_dir():
-                continue
-            encoded = project_dir.name
-            real_path = Path("/" + encoded.lstrip("-").replace("-", "/"))
+        from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+        for real_path in iter_claude_project_paths():
             rules_dir = real_path / ".claude" / "rules"
             if not rules_dir.is_dir():
                 continue
@@ -95,15 +90,11 @@ class ClaudeRulesRecord(Record):
         user_rules_dir = _CLAUDE_HOME / "rules"
         if user_rules_dir.is_dir():
             count += sum(1 for _ in user_rules_dir.glob("*.md"))
-        if _CLAUDE_PROJECTS.is_dir():
-            for project_dir in _CLAUDE_PROJECTS.iterdir():
-                if not project_dir.is_dir():
-                    continue
-                encoded = project_dir.name
-                real_path = Path("/" + encoded.lstrip("-").replace("-", "/"))
-                rules_dir = real_path / ".claude" / "rules"
-                if rules_dir.is_dir():
-                    count += sum(1 for _ in rules_dir.glob("*.md"))
+        from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+        for real_path in iter_claude_project_paths():
+            rules_dir = real_path / ".claude" / "rules"
+            if rules_dir.is_dir():
+                count += sum(1 for _ in rules_dir.glob("*.md"))
         return min(count, limit) if limit is not None else count
 
     @classmethod

--- a/flow_sdk/fs_records/markdown_record.py
+++ b/flow_sdk/fs_records/markdown_record.py
@@ -20,11 +20,46 @@ from ._frontmatter import (
     _yaml_load,
 )
 
+_WALK_IGNORED: frozenset[str] = frozenset({
+    ".git", "node_modules", ".venv", "venv", "__pycache__",
+    ".tox", "dist", "build", ".eggs", ".mypy_cache", ".pytest_cache",
+    ".ruff_cache", ".next", ".nuxt", "coverage", ".cache",
+})
+
+
+_DOCS_WALK_MAX_DEPTH = 3
+
+
+def _find_docs_subdirs(root: Path) -> list[Path]:
+    """Return all directories named 'docs' anywhere under root.
+
+    Skips common noise directories (node_modules, .git, build outputs, etc.)
+    and stops at _DOCS_WALK_MAX_DEPTH levels deep to keep the walk fast.
+    """
+    found: list[Path] = []
+    root_depth = len(root.parts)
+    try:
+        for dirpath, dirnames, _ in os.walk(root, topdown=True):
+            p = Path(dirpath)
+            depth = len(p.parts) - root_depth
+            if depth >= _DOCS_WALK_MAX_DEPTH:
+                dirnames.clear()
+                continue
+            dirnames[:] = [d for d in dirnames if d not in _WALK_IGNORED]
+            if p.name == "docs":
+                found.append(p)
+    except PermissionError:
+        pass
+    return found
+
+
 def _doc_search_dirs() -> list[Path]:
     """Return directories to scan for doc .md files.
 
-    Scans user-level (~/.claude/docs), cwd/.claude/docs if present,
-    and any extra dirs from FLOWPAD_DOC_DIRS (colon-separated).
+    Scans user-level (~/.claude/docs), all known Claude projects
+    (every 'docs' directory anywhere in each project tree, plus
+    <project>/.claude/docs), cwd-level, and any extra dirs from
+    FLOWPAD_DOC_DIRS (colon-separated).
     """
     dirs: list[Path] = []
     seen: set[Path] = set()
@@ -36,8 +71,16 @@ def _doc_search_dirs() -> list[Path]:
             dirs.append(p)
 
     _add(Path.home() / ".claude" / "docs")
+
+    from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+    for real in iter_claude_project_paths():
+        for docs_dir in _find_docs_subdirs(real):
+            _add(docs_dir)
+        _add(real / ".claude" / "docs")
+
     _add(Path(os.getcwd()) / ".claude" / "docs")
-    _add(Path(os.getcwd()) / "docs")
+    for docs_dir in _find_docs_subdirs(Path(os.getcwd())):
+        _add(docs_dir)
 
     for extra in os.environ.get("FLOWPAD_DOC_DIRS", "").split(":"):
         if extra.strip():

--- a/flow_sdk/fs_records/skill_record.py
+++ b/flow_sdk/fs_records/skill_record.py
@@ -15,8 +15,9 @@ from ._frontmatter import _coerce_scalar, _extract_frontmatter, _yaml_load  # no
 def _skill_search_dirs() -> list[Path]:
     """Return directories to scan for skill folders.
 
-    Scans user-level (~/.claude/skills) and the cwd/.claude/skills if present
-    (covers project-level skills when the server runs from the project dir).
+    Scans user-level (~/.claude/skills), all known Claude projects
+    (<project>/.claude/skills), cwd-level, and any extra dirs from
+    FLOWPAD_SKILL_DIRS (colon-separated).
     """
     import os
     dirs: list[Path] = []
@@ -29,6 +30,11 @@ def _skill_search_dirs() -> list[Path]:
             dirs.append(p)
 
     _add(Path.home() / ".claude" / "skills")
+
+    from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+    for real in iter_claude_project_paths():
+        _add(real / ".claude" / "skills")
+
     _add(Path(os.getcwd()) / ".claude" / "skills")
 
     for extra in os.environ.get("FLOWPAD_SKILL_DIRS", "").split(":"):

--- a/flow_sdk/fs_records/workflow_record.py
+++ b/flow_sdk/fs_records/workflow_record.py
@@ -19,8 +19,9 @@ from flow_sdk.fs_store import Record, RecordType
 def _workflow_search_dirs() -> list[Path]:
     """Return directories to scan for workflow .md files.
 
-    Scans user-level (~/.claude/workflows), cwd/.claude/workflows if present,
-    and any extra dirs from FLOWPAD_WORKFLOW_DIRS (colon-separated).
+    Scans user-level (~/.claude/workflows), all known Claude projects
+    (<project>/.claude/workflows), cwd-level, and any extra dirs from
+    FLOWPAD_WORKFLOW_DIRS (colon-separated).
     """
     dirs: list[Path] = []
     seen: set[Path] = set()
@@ -32,6 +33,11 @@ def _workflow_search_dirs() -> list[Path]:
             dirs.append(p)
 
     _add(Path.home() / ".claude" / "workflows")
+
+    from flow_sdk.fs_records._claude_projects import iter_claude_project_paths
+    for real in iter_claude_project_paths():
+        _add(real / ".claude" / "workflows")
+
     _add(Path(os.getcwd()) / ".claude" / "workflows")
 
     for extra in os.environ.get("FLOWPAD_WORKFLOW_DIRS", "").split(":"):

--- a/flow_sdk/fs_store/record.py
+++ b/flow_sdk/fs_store/record.py
@@ -1903,7 +1903,7 @@ class Record:
                 await driver.fts_delete(entity.id)
             await entity.delete()
 
-    async def sync_to_db(self, fts_batch: "list | None" = None) -> None:
+    async def sync_to_db(self, fts_batch: "list | None" = None, notify: bool = True) -> None:
         """Create or update the corresponding Entity in SQLite.
 
         If ``fts_batch`` is provided the FtsEntry is appended to it instead of
@@ -1916,7 +1916,7 @@ class Record:
 
         try:
             # Step 1: Entity row (delegates to Entity.from_record)
-            entity = await Entity.from_record(self)
+            entity = await Entity.from_record(self, notify=notify)
 
             # Write entity's db_json() back to metadata.json so disk reflects entity state,
             # then write the hash sentinel (sync_from_entity handles both).

--- a/flow_sdk/fs_store/schema_registry.py
+++ b/flow_sdk/fs_store/schema_registry.py
@@ -784,7 +784,7 @@ class SchemaRegistry:
                 batch_fts: list = []
 
                 async def _index_one(rec, _fts=batch_fts):
-                    await rec.sync_to_db(fts_batch=_fts)
+                    await rec.sync_to_db(fts_batch=_fts, notify=False)
 
                 results = await asyncio.gather(
                     *[_index_one(r) for r in batch],
@@ -977,7 +977,7 @@ class SchemaRegistry:
                 skipped += 1
             else:
                 try:
-                    await rec.sync_to_db(fts_batch=fts_batch)
+                    await rec.sync_to_db(fts_batch=fts_batch, notify=False)
                     indexed += 1
                 except Exception:
                     errors += 1

--- a/flow_sdk/server/run.py
+++ b/flow_sdk/server/run.py
@@ -120,38 +120,9 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 9007
 
 
-def _register_project_asset_dirs() -> None:
-    """Register project-level .claude/skills and .claude/agents dirs via env vars.
-
-    Uses the server's working directory as the project root. Extra dirs are
-    appended to FLOWPAD_SKILL_DIRS / FLOWPAD_AGENT_DIRS (colon-separated).
-    """
-    from pathlib import Path
-    # Derive repo root from __file__ (flow_sdk/server/run.py → 3 levels up)
-    # This is reliable regardless of how/where the server is invoked.
-    # TODO find a better solution
-    cwd = Path(__file__).resolve().parent.parent.parent
-    candidates = [
-        ("FLOWPAD_SKILL_DIRS", ".claude/skills"),
-        ("FLOWPAD_AGENT_DIRS", ".claude/agents"),
-        ("FLOWPAD_DOC_DIRS", ".claude/docs"),
-        ("FLOWPAD_DOC_DIRS", "docs"),
-        ("FLOWPAD_PLAN_DIRS", ".claude/plans"),
-        ("FLOWPAD_WORKFLOW_DIRS", ".claude/workflows"),
-    ]
-    for env_var, subdir in candidates:
-        candidate = cwd / subdir
-        if candidate.is_dir():
-            existing = os.environ.get(env_var, "")
-            candidate_str = str(candidate)
-            if candidate_str not in existing.split(":"):
-                os.environ[env_var] = f"{existing}:{candidate_str}" if existing else candidate_str
-
-
 def main():
     """Start the minihub server."""
     startup_start = time.time()
-    _register_project_asset_dirs()
 
     if not _acquire_singleton_lock():
         print(f"[pid={os.getpid()}] Another server instance is already running. Exiting.")

--- a/tests/unit/test_claude_projects.py
+++ b/tests/unit/test_claude_projects.py
@@ -1,0 +1,195 @@
+"""Unit tests for flow_sdk.fs_records._claude_projects.
+
+Tests cover:
+- _real_path_from_jsonl: reads 'cwd' from a session JSONL file
+- iter_claude_project_paths: yields real paths, deduplicates, handles hyphens
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from flow_sdk.fs_records._claude_projects import (
+    _real_path_from_jsonl,
+    iter_claude_project_paths,
+)
+
+
+# ---------------------------------------------------------------------------
+# _real_path_from_jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_reads_cwd_from_jsonl(tmp_path: Path) -> None:
+    """Returns the Path from the first 'cwd' field found in a JSONL file."""
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(
+        json.dumps({"type": "user", "cwd": "/Users/foo/my-project"}) + "\n"
+    )
+    result = _real_path_from_jsonl(tmp_path)
+    assert result == Path("/Users/foo/my-project")
+
+
+def test_skips_lines_without_cwd(tmp_path: Path) -> None:
+    """Returns the first line that has 'cwd', skipping earlier lines without it."""
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(
+        json.dumps({"type": "assistant", "text": "hello"}) + "\n"
+        + json.dumps({"type": "user", "cwd": "/Users/foo/real-path"}) + "\n"
+    )
+    result = _real_path_from_jsonl(tmp_path)
+    assert result == Path("/Users/foo/real-path")
+
+
+def test_returns_none_when_no_jsonl(tmp_path: Path) -> None:
+    """Returns None when there are no JSONL files."""
+    result = _real_path_from_jsonl(tmp_path)
+    assert result is None
+
+
+def test_returns_none_when_no_cwd_field(tmp_path: Path) -> None:
+    """Returns None when JSONL files exist but none contain 'cwd'."""
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(json.dumps({"type": "assistant", "text": "hi"}) + "\n")
+    result = _real_path_from_jsonl(tmp_path)
+    assert result is None
+
+
+def test_handles_malformed_lines(tmp_path: Path) -> None:
+    """Skips malformed JSON lines and continues to valid ones."""
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(
+        "not json at all\n"
+        + json.dumps({"cwd": "/Users/foo/ok"}) + "\n"
+    )
+    result = _real_path_from_jsonl(tmp_path)
+    assert result == Path("/Users/foo/ok")
+
+
+# ---------------------------------------------------------------------------
+# iter_claude_project_paths
+# ---------------------------------------------------------------------------
+
+
+def _make_project_dir(
+    base: Path,
+    encoded_name: str,
+    real_cwd: str | None = None,
+) -> Path:
+    """Create a fake ~/.claude/projects/<encoded> directory."""
+    project_dir = base / encoded_name
+    project_dir.mkdir(parents=True)
+    if real_cwd is not None:
+        jsonl = project_dir / "session.jsonl"
+        jsonl.write_text(json.dumps({"type": "user", "cwd": real_cwd}) + "\n")
+    return project_dir
+
+
+def test_yields_real_path_from_jsonl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Yields the path decoded from JSONL cwd, not from the encoded name."""
+    projects_root = tmp_path / ".claude" / "projects"
+    real_dir = tmp_path / "my-project"
+    real_dir.mkdir()
+    _make_project_dir(projects_root, "-Users-foo-my-project", real_cwd=str(real_dir))
+
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._CLAUDE_PROJECTS", projects_root
+    )
+    result = list(iter_claude_project_paths())
+    assert result == [real_dir]
+
+
+def test_falls_back_to_decode_when_no_jsonl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Falls back to hyphen-decode when _real_path_from_jsonl returns None.
+
+    Uses Path.home() as the target because it has no hyphens in the path and
+    is guaranteed to exist — tmp_path contains pytest-generated hyphens that
+    would make the naive decode produce the wrong path.
+    """
+    projects_root = tmp_path / ".claude" / "projects"
+    real_dir = Path.home().resolve()
+    encoded = "-" + str(real_dir).lstrip("/").replace("/", "-")
+    _make_project_dir(projects_root, encoded, real_cwd=None)  # no JSONL
+
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._CLAUDE_PROJECTS", projects_root
+    )
+    # Patch _real_path_from_jsonl to return None (simulate empty project dir)
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._real_path_from_jsonl",
+        lambda _: None,
+    )
+    result = list(iter_claude_project_paths())
+    assert result == [real_dir]
+
+
+def test_deduplicates_same_real_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Does not yield the same real path twice even if two encoded dirs point to it."""
+    projects_root = tmp_path / ".claude" / "projects"
+    real_dir = tmp_path / "project"
+    real_dir.mkdir()
+    _make_project_dir(projects_root, "-a", real_cwd=str(real_dir))
+    _make_project_dir(projects_root, "-b", real_cwd=str(real_dir))
+
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._CLAUDE_PROJECTS", projects_root
+    )
+    result = list(iter_claude_project_paths())
+    assert len(result) == 1
+    assert result[0] == real_dir
+
+
+def test_skips_nonexistent_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Does not yield paths that don't exist on disk."""
+    projects_root = tmp_path / ".claude" / "projects"
+    _make_project_dir(
+        projects_root, "-Users-ghost-nowhere", real_cwd="/Users/ghost/nowhere"
+    )  # path does not exist
+
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._CLAUDE_PROJECTS", projects_root
+    )
+    result = list(iter_claude_project_paths())
+    assert result == []
+
+
+def test_hyphenated_project_name_resolved_correctly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A project path with hyphens (e.g. flow-cli) is resolved via JSONL, not decode."""
+    projects_root = tmp_path / ".claude" / "projects"
+    # Real path has a hyphen — naive decode would give wrong result
+    real_dir = tmp_path / "flow-cli"
+    real_dir.mkdir()
+    _make_project_dir(
+        projects_root, "-Users-foo-flow-cli", real_cwd=str(real_dir)
+    )
+
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._CLAUDE_PROJECTS", projects_root
+    )
+    result = list(iter_claude_project_paths())
+    assert result == [real_dir]
+
+
+def test_empty_projects_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns empty list when projects dir exists but is empty."""
+    projects_root = tmp_path / ".claude" / "projects"
+    projects_root.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._CLAUDE_PROJECTS", projects_root
+    )
+    assert list(iter_claude_project_paths()) == []
+
+
+def test_missing_projects_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns empty list when ~/.claude/projects doesn't exist."""
+    monkeypatch.setattr(
+        "flow_sdk.fs_records._claude_projects._CLAUDE_PROJECTS",
+        tmp_path / "nonexistent",
+    )
+    assert list(iter_claude_project_paths()) == []


### PR DESCRIPTION
## Summary

- **Cross-project discovery**: All five record types (docs, plans, workflows, skills, agents) now scan every project the user has worked in with Claude, by reading `~/.claude/projects/` via the new `iter_claude_project_paths()` helper
- **Hyphen-decode bug fix**: The existing path decode (`-Users-foo-my-app` → `/Users/foo/my/app`) broke for paths with hyphens. Fixed by reading the `cwd` field from session JSONL files, which store the original unencoded path. Falls back to naive decode only when no JSONL exists
- **Nested docs discovery**: `_find_docs_subdirs()` walks each project tree (depth ≤ 3, ignoring node_modules/.git/build) to find `docs/` directories at any level — not just the project root
- **FTS body indexing**: `MarkdownRecord.search_content` now indexes the full document body, not just wiki links
- **Remove redundant startup code**: `_register_project_asset_dirs()` in `server/run.py` is removed — project dirs are now discovered at scan time via `iter_claude_project_paths()`
- **Pre-existing bug fixes**: Same hyphen-decode bug fixed in `claude_rules`, `claude_claude_md`, and `claude_memory`
- **Unit tests**: 12 tests covering `_real_path_from_jsonl` and `iter_claude_project_paths`
- **Fix bulk indexing: suppress WS notification storm**: All `sync_to_db` / `from_record` / `save()` calls in bulk index paths now pass `notify=False` — previously each entity save fired a WebSocket notification causing the UI to re-fetch all entities of that type, creating an N² read storm (739 annotations × 739 fetches = ~550K DB reads, taking 2–3 minutes)
- **Fix `notify` propagation through Entity subclasses**: `DBEntity.save()` gained a `notify` parameter but it was missing from all overrides (`Entity`, `Workspace`, `WebDomain`, `ApiKey`, `Mention`). This caused `TypeError: Entity.save() got an unexpected keyword argument 'notify'` on every record during indexing, silently filling `~/.flow/records/record_error/` with 1869 error files and leaving the DB completely empty after a full re-index

## Test plan

- [ ] Run scan — docs/plans/skills from other projects (e.g. flow-cli, skillit) appear in results
- [ ] Search "test123" — finds `skillit/hooks/docs/test.md`
- [ ] Search "test456" — finds `flow-cli/docs/test.md`
- [ ] Project with hyphen in path (flow-cli) resolves correctly, not as flow/cli
- [ ] `python -m pytest tests/unit/test_claude_projects.py -v` — all 12 pass
- [ ] After "refresh search data": all record types (annotations, docs, skills, etc.) are indexed with no errors in `~/.flow/records/record_error/`
- [ ] Index of 700+ annotations completes in seconds, not minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)