### PR TITLE
feat: cross-user task notification system (FLOWPAD-1832)

### DIFF
--- a/flow_sdk/builtin/project.py
+++ b/flow_sdk/builtin/project.py
@@ -94,12 +94,15 @@ class Project(Entity):
 
     @classmethod
     def allocate_id(cls, data: dict) -> str:
-        """Deterministic UUID5 keyed on the project work directory."""
+        """Deterministic UUID5 keyed on the project work directory.
+
+        The deterministic ID takes priority over any client-provided id, because
+        the frontend always assigns a random UUID4 to new entities before saving.
+        Only fall back to the provided id (or a fresh UUID4) when no mount path
+        is available to derive a stable key from.
+        """
         import uuid
         from flow_sdk.fs_store.identifier import is_valid_uuid
-        rid = data.get("id") or ""
-        if rid and is_valid_uuid(rid):
-            return rid
         mount_path = data.get("fs_storage_mount_path") or data.get("real_path")
         if not mount_path:
             name = data.get("name", "")
@@ -107,6 +110,9 @@ class Project(Entity):
                 mount_path = name
         if mount_path:
             return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"project:{mount_path}"))
+        rid = data.get("id") or ""
+        if rid and is_valid_uuid(rid):
+            return rid
         return str(uuid.uuid4())
 
     @property

--- a/flow_sdk/server/routes/notify.py
+++ b/flow_sdk/server/routes/notify.py
@@ -27,8 +27,7 @@ router = APIRouter()
 
 def _get_ui_port() -> int:
     import os
-    info = load_server_info()
-    return int(info.get("port") or os.environ.get("LOCAL_SERVER_PORT", "9007"))
+    return int(os.environ.get("VITE_PORT") or os.environ.get("LOCAL_SERVER_PORT", "9007"))
 
 
 _REDIRECT_HTML = """<!DOCTYPE html>

--- a/tests/api/test_agent_hook.py
+++ b/tests/api/test_agent_hook.py
@@ -419,10 +419,14 @@ def test_sniffer_webhook_e2e_via_websocket():
             assert resp.status_code == 200, f"listen failed: {resp.text}"
 
             # 5. Receive flow_data_msg on WebSocket
-            msg = ws.receive_json()
-            assert msg["message_type"] == "flow_data_msg", (
-                f"Expected flow_data_msg, got: {json.dumps(msg, indent=2)}"
-            )
+            # Drain any background data_op_msg events (e.g. from the startup scanner)
+            # before asserting on the expected flow_data_msg.
+            for _ in range(10):
+                msg = ws.receive_json()
+                if msg["message_type"] == "flow_data_msg":
+                    break
+            else:
+                raise AssertionError(f"Expected flow_data_msg, got: {json.dumps(msg, indent=2)}")
             # Verify the flow_data contains the webhook payload
             flow_data = msg["flow_data"]
             assert flow_data["attributes"]["webhook_type"] == "hook_op"

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -29,6 +29,9 @@ export default defineConfig(({ mode }) => {
     server: {
       host: 'localhost',
       port: parseInt(env.VITE_PORT || '4097'),
+      proxy: {
+        '/api/v1/notify': `http://localhost:${env.LOCAL_SERVER_PORT || '9007'}`,
+      },
       fs: {
         allow: [
           path.resolve(__dirname, './'),

--- a/uv.lock
+++ b/uv.lock
@@ -848,6 +848,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-env" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "twine" },
@@ -905,6 +906,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = "==0.24.0" },
     { name = "pytest-env", specifier = ">=1.2.0" },
+    { name = "pytest-rerunfailures", specifier = ">=16.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "twine" },
@@ -2666,6 +2668,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/12/9c87d0ca45d5992473208bcef2828169fa7d39b8d7fc6e3401f5c08b8bf7/pytest_env-1.2.0.tar.gz", hash = "sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80", size = 8973, upload-time = "2025-10-09T19:15:47.42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/98/822b924a4a3eb58aacba84444c7439fce32680592f394de26af9c76e2569/pytest_env-1.2.0-py3-none-any.whl", hash = "sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00", size = 6251, upload-time = "2025-10-09T19:15:46.077Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New **cross-user notification flow**: sender shares a Task+Spec via git push + cloud POST; recipient receives an in-app notification (WS) and email, then opens the task in SharedTaskView
- New entities: `Spec`, `CrossUserNotification` (merged into `Notification`)
- New backend: `notification_action.py` (send + open-task actions), `cross_notification_scanner.py`, `notify.py` deep-link route
- New frontend: `SendNotificationDialog`, `SendPlanNotificationDialog`, `SharedTaskView`, task sharing button in `TaskBar` and `PlanEditor`
- Git utilities consolidated into `flow_sdk/utils/git.py`
- `Project.allocate_id`: UUID5 from mount path now takes priority over client-provided UUID4
- Vite dev proxy for `/api/v1/notify` to avoid React Router 404 in dev mode
- Fix `test_sniffer_webhook_e2e_via_websocket`: drain background `data_op_msg` frames before asserting

## Test plan

- [ ] Send notification from PlanEditor → task + spec written to git, pushed, cloud notified
- [ ] Recipient receives in-app notification popup (WS `flow_data_msg` with `type=notification`)
- [ ] Recipient clicks bookmark → `openTaskNotification` pulls repo, opens SharedTaskView
- [ ] SharedTaskView shows spec content, "Claude It" button, conversation thread, reply input
- [ ] `/api/v1/notify?project_url=...&task_id=...` deep-link redirects to task view
- [ ] `test_sniffer_webhook_e2e_via_websocket` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)