### PR TITLE
FlowMessage file transport (.flowmsg) — conversation, session, and UI fixes

### DIFF
--- a/flow_sdk/app/actions/flow_message_action.py
+++ b/flow_sdk/app/actions/flow_message_action.py
@@ -173,9 +173,9 @@ async def handle_download_flow_message(fm_id: str) -> ApiResponse:
         return ApiFailResponse(message=f"FlowMessage not found: {fm_id}", status_code=404)
 
     zip_path = await fm.to_file()
-    short_id = fm_id[:8]
-    task_id = next((c.id for c in fm.context if c.type == BuiltinEntityType.TASK.value), "msg")
-    filename = f"task-{task_id[:8]}-{short_id}.flowmsg"
+    sender = re.sub(r"[^a-z0-9]+", "-", (fm.sender_name or "unknown").lower()).strip("-")[:30]
+    dt = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    filename = f"{sender}-{dt}.flowmsg"
 
     return FileResponse(
         str(zip_path),

--- a/flow_sdk/fs_records/flow_message_bundle.py
+++ b/flow_sdk/fs_records/flow_message_bundle.py
@@ -199,6 +199,38 @@ def _rewrite_file_attachments(fm_data: dict, tmp_root: Path, task_id: str) -> No
 
 
 # ---------------------------------------------------------------------------
+# _merge_conversation_jsonl
+# ---------------------------------------------------------------------------
+
+def _merge_conversation_jsonl(bundle_jsonl: Path, dest: Path) -> None:
+    """Write a merged conversation.jsonl to dest.
+
+    Keeps all existing local pointers in dest, then appends any pointers from
+    bundle_jsonl whose message_id is not already present (preserving local replies).
+    """
+    def _read_ptrs(path: Path) -> list[dict]:
+        ptrs: list[dict] = []
+        if not path.exists():
+            return ptrs
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    ptrs.append(json.loads(line))
+                except Exception:
+                    pass
+        return ptrs
+
+    existing = _read_ptrs(dest)
+    existing_ids = {p.get("message_id") for p in existing}
+    new_ptrs = [p for p in _read_ptrs(bundle_jsonl) if p.get("message_id") not in existing_ids]
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8") as fh:
+        for ptr in existing + new_ptrs:
+            fh.write(json.dumps(ptr) + "\n")
+
+
+# ---------------------------------------------------------------------------
 # unpack_bundle
 # ---------------------------------------------------------------------------
 
@@ -296,13 +328,20 @@ async def unpack_bundle(
                         task_id = task_data.get("id") or entry_id
                         existing_task = await Task.get_one({"id": task_id})
                         if existing_task is None or overwrite:
+                            # Merge metadata: keep agentic_* keys from existing task so
+                            # session resume still works after re-upload.
+                            bundle_meta: dict = task_data.get("metadata") or {}
+                            if existing_task and existing_task.metadata:
+                                existing_meta = dict(existing_task.metadata)
+                                agentic_keys = {k: v for k, v in existing_meta.items() if k.startswith("agentic_")}
+                                bundle_meta = {**bundle_meta, **agentic_keys}
                             task = Task.model_validate({
                                 "id": task_id,
                                 "title": task_data.get("title", ""),
                                 "spec_id": task_data.get("spec_id"),
                                 "shared_by_id": task_data.get("shared_by_id"),
                                 "conversation_id": task_data.get("conversation_id"),
-                                "metadata": task_data.get("metadata"),
+                                "metadata": bundle_meta or None,
                                 "status": task_data.get("status", "to_do"),
                             })
                             await task.save(owner_typeid)
@@ -324,7 +363,7 @@ async def unpack_bundle(
                         perm_task_dir = FLOW_HOME / "tasks" / f"{task_title_slug}-{(task_id_for_conv or entry_id)[:8]}"
                         perm_task_dir.mkdir(parents=True, exist_ok=True)
                         perm_jsonl = perm_task_dir / "conversation.jsonl"
-                        shutil.copy2(jsonl_file, perm_jsonl)
+                        _merge_conversation_jsonl(jsonl_file, perm_jsonl)
                         conv = await _create_conversation_from_disk(
                             task_dir=perm_task_dir,
                             task_id=task_id_for_conv or "",

--- a/flow_sdk/fs_records/flow_message_bundle.py
+++ b/flow_sdk/fs_records/flow_message_bundle.py
@@ -296,21 +296,13 @@ async def unpack_bundle(
                         task_id = task_data.get("id") or entry_id
                         existing_task = await Task.get_one({"id": task_id})
                         if existing_task is None or overwrite:
-                            # Merge metadata: start with existing (receiver-side keys like
-                            # agentic_session_id, agentic_executed_count) then overlay
-                            # bundle keys (sender-side keys like project_root, sender_name).
-                            merged_metadata: dict = {}
-                            if existing_task and existing_task.metadata:
-                                merged_metadata.update(existing_task.metadata)
-                            if task_data.get("metadata"):
-                                merged_metadata.update(task_data["metadata"])
                             task = Task.model_validate({
                                 "id": task_id,
                                 "title": task_data.get("title", ""),
                                 "spec_id": task_data.get("spec_id"),
                                 "shared_by_id": task_data.get("shared_by_id"),
                                 "conversation_id": task_data.get("conversation_id"),
-                                "metadata": merged_metadata or None,
+                                "metadata": task_data.get("metadata"),
                                 "status": task_data.get("status", "to_do"),
                             })
                             await task.save(owner_typeid)

--- a/ts_sdk/src/process/agentic-process.ts
+++ b/ts_sdk/src/process/agentic-process.ts
@@ -211,12 +211,15 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
       ...(options.resumeSessionId
         ? options.forkSession
           ? { resume: true, fork_session_id: options.resumeSessionId }
-          : { resume: true }
+          : { resume: true, session_id: options.resumeSessionId }
         : {}),
     });
 
     const process = await new AgenticProcess({
       cli_config: cliConfig.toJson(),
+      // When resuming, seed session_id on the entity so Python's start() keeps it
+      // instead of generating a new UUID (which would break transcript lookup).
+      ...(options.resumeSessionId && !options.forkSession ? { session_id: options.resumeSessionId } : {}),
       context_data: {
         instructions: options.instructions,
         project_id: options.projectId,

--- a/ui/src/components/conversation/ConversationView.tsx
+++ b/ui/src/components/conversation/ConversationView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Sparkles } from 'lucide-react';
-import { AgenticProcess, Conversation, dataContext, dataManager, FlowMessage, Spec, Task, TypeId } from '@sdk';
+import { FolderOpen, Sparkles } from 'lucide-react';
+import { AgenticProcess, Conversation, dataContext, dataManager, FlowMessage, ProcessStatus, Spec, Task, TypeId } from '@sdk';
 import { useEntity } from '@sdk/react/hooks';
 import { ExpansionRequest } from '@sdk/FlowSync/query';
 import { AttachmentType } from '@sdk/entities/flow-message';
@@ -16,9 +16,10 @@ interface ConversationViewProps {
   conversationId: string;
   task: ITask;
   senderName?: string;
+  onChooseProject?: () => void;
 }
 
-export function ConversationView({ conversationId, task, senderName }: ConversationViewProps) {
+export function ConversationView({ conversationId, task, senderName, onChooseProject }: ConversationViewProps) {
   const { navigation } = useDockNavigation();
   const taskId = task.id ?? '';
   const [lastExecutedCount, setLastExecutedCount] = useState(-1);
@@ -35,6 +36,8 @@ export function ConversationView({ conversationId, task, senderName }: Conversat
   const pointers = conversation?.conversationMessageIds ?? [];
   const taskMeta = (task.metadata as Record<string, unknown> | undefined) ?? {};
   const storedSessionId = taskMeta.agentic_session_id as string | undefined;
+  const storedWorkdir = taskMeta.agentic_workdir as string | undefined;
+  const storedProcessId = taskMeta.agentic_process_id as string | undefined;
   const storedExecutedCount = (taskMeta.agentic_executed_count as number | undefined) ?? -1;
   // Effective cursor: use local state if already set this session, otherwise fall back to DB value
   const effectiveExecutedCount = lastExecutedCount >= 0 ? lastExecutedCount : storedExecutedCount;
@@ -102,21 +105,58 @@ export function ConversationView({ conversationId, task, senderName }: Conversat
       const workdir = taskMeta.project_root as string | undefined
         ?? dataContext.project?.fs_storage_mount_path;
 
-      // In-memory cache: PTY is still live, send instruction directly
+      // ── Session routing ────────────────────────────────────────────────
+      // Priority: in-memory cache → reconnect live process → resume dead session → first spawn
       const cached = taskSessionCache.get(taskId);
       if (cached) {
+        // PTY client still live in this browser session — send directly
         await cached.executeInstruction(prompt, { sync: false });
         navigation.openDock(cached.dockPointer);
+      } else if (storedProcessId) {
+        // Page was refreshed — try to reconnect to the existing process
+        const existingProcess = await dataManager.getByTypeId<AgenticProcess>(
+          new TypeId(AgenticProcess.type, storedProcessId),
+        ).catch(() => null);
+
+        const isAlive = existingProcess &&
+          existingProcess.status !== ProcessStatus.STOPPED &&
+          existingProcess.status !== ProcessStatus.FAILED &&
+          existingProcess.status !== ProcessStatus.STOPPING;
+
+        if (isAlive) {
+          // Process is still running — reconnect PTY and deliver instruction via start()
+          // (avoids the stale workerStatus check in executeInstruction after a page refresh)
+          await existingProcess!.start({ instruction: prompt });
+          taskSessionCache.set(taskId, existingProcess!);
+          navigation.openDock(existingProcess!.dockPointer);
+        } else {
+          // Process is dead — close it, spawn a resumed session with the same Claude session_id
+          if (existingProcess) await existingProcess.close().catch(() => {});
+          const { process: resumed } = await AgenticProcess.spawn(
+            { workdir: storedWorkdir ?? workdir, resumeSessionId: storedSessionId },
+            { instruction: prompt, visible: true },
+          );
+          taskSessionCache.set(taskId, resumed);
+          navigation.openDock(resumed.dockPointer);
+          const tResume = await dataManager.getByTypeId<Task>(new TypeId(Task.type, taskId));
+          if (tResume) {
+            tResume.metadata = { ...(tResume.metadata ?? {}), agentic_process_id: resumed.id };
+            await tResume.save();
+          }
+        }
       } else if (storedSessionId) {
-        // App restarted — resume the Claude session transcript via a new spawn.
-        // spawn({ resumeSessionId }) never conflicts with an existing PTY; it
-        // creates a fresh AgenticProcess entity that continues the same transcript.
+        // Legacy: session_id stored but process_id not tracked — resume fresh
         const { process: resumed } = await AgenticProcess.spawn(
-          { workdir, resumeSessionId: storedSessionId },
+          { workdir: storedWorkdir ?? workdir, resumeSessionId: storedSessionId },
           { instruction: prompt, visible: true },
         );
         taskSessionCache.set(taskId, resumed);
         navigation.openDock(resumed.dockPointer);
+        const tLegacy = await dataManager.getByTypeId<Task>(new TypeId(Task.type, taskId));
+        if (tLegacy) {
+          tLegacy.metadata = { ...(tLegacy.metadata ?? {}), agentic_process_id: resumed.id };
+          await tLegacy.save();
+        }
       } else {
         // First run — spawn a brand-new session
         const { process: agenticProcess } = await AgenticProcess.spawn(
@@ -125,11 +165,16 @@ export function ConversationView({ conversationId, task, senderName }: Conversat
         );
         taskSessionCache.set(taskId, agenticProcess);
         navigation.openDock(agenticProcess.dockPointer);
-        // Persist the Claude session_id (not entity id) — stable across process entities
+        // Persist session_id, workdir, and process_id — all needed for reliable resume
         if (agenticProcess.session_id) {
           const t = await dataManager.getByTypeId<Task>(new TypeId(Task.type, taskId));
           if (t) {
-            t.metadata = { ...(t.metadata ?? {}), agentic_session_id: agenticProcess.session_id };
+            t.metadata = {
+              ...(t.metadata ?? {}),
+              agentic_session_id: agenticProcess.session_id,
+              agentic_workdir: workdir,
+              agentic_process_id: agenticProcess.id,
+            };
             await t.save();
           }
         }
@@ -166,20 +211,32 @@ export function ConversationView({ conversationId, task, senderName }: Conversat
         </div>
       )}
 
-      {/* Execute button — shown only for shared tasks (spec_id present) */}
+      {/* Execute + Choose Project buttons */}
       {task.spec_id && (
-        <button
-          onClick={() => void handleExecute()}
-          disabled={executing || (hasExecuted && !hasDelta)}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <Sparkles className="h-4 w-4" />
-          {executing
-            ? 'Starting…'
-            : hasExecuted
-              ? 'Continue Execution with Claude Code'
-              : 'Execute the task with Claude Code'}
-        </button>
+        <div className="flex gap-1">
+          <button
+            onClick={() => void handleExecute()}
+            disabled={executing}
+            className="flex flex-[19] items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Sparkles className="h-4 w-4" />
+            {executing
+              ? 'Starting…'
+              : hasExecuted
+                ? 'Continue Execution with Claude Code'
+                : 'Execute the task with Claude Code'}
+          </button>
+          {onChooseProject && (
+            <button
+              onClick={onChooseProject}
+              title="Choose project folder"
+              className="flex flex-[4] items-center justify-center gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <FolderOpen className="h-4 w-4 shrink-0" />
+              Choose Project
+            </button>
+          )}
+        </div>
       )}
 
       <MessageComposer task={task} onSent={() => void refetch()} />

--- a/ui/src/components/task-bar/SharedTaskView.tsx
+++ b/ui/src/components/task-bar/SharedTaskView.tsx
@@ -6,11 +6,10 @@
  */
 
 import { useState } from 'react';
-import { ArrowLeft, FolderOpen, MessageSquare, Sparkles } from 'lucide-react';
-import { AgenticProcess, dataContext, Spec, Task, TypeId } from '@sdk';
+import { ArrowLeft, MessageSquare } from 'lucide-react';
+import { Spec, Task, TypeId } from '@sdk';
 import { useEntity } from '@sdk/react/hooks';
 import { ExpansionRequest } from '@sdk/FlowSync/query';
-import { useDockNavigation } from '@src/navigation/useDockNavigation';
 import { ConversationView } from '@src/components/conversation';
 import { OpenProjectComponent } from '@src/components/open-project-component/open-project-component';
 
@@ -20,13 +19,11 @@ interface SharedTaskViewProps {
 }
 
 export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
-  const { navigation } = useDockNavigation();
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
 
   const blobExpansion = new ExpansionRequest({ expand: ['blobs'] });
 
   const taskMeta = task.metadata as Record<string, unknown> | undefined;
-  const projectRoot = taskMeta?.project_root as string | undefined;
   const senderName = taskMeta?.sender_name as string | undefined
     || task.shared_by_id
     || 'Unknown';
@@ -35,31 +32,6 @@ export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
     task.spec_id ? new TypeId(Spec.type, task.spec_id) : null,
     { query: blobExpansion },
   );
-
-  const handleClaudeIt = async () => {
-    const specContent = spec?.content ?? '';
-    const specTitle = spec?.title ?? task.title ?? 'Untitled';
-    const prompt = [
-      `You received a task from ${senderName}: "${specTitle}"`,
-      '',
-      specContent
-        ? `Here is the plan:\n\n${specContent}`
-        : `Task: ${task.title || 'Untitled'}`,
-      '',
-      'Please read through the plan carefully and confirm you have everything you need to get started. If anything is unclear or missing, ask before proceeding.',
-    ].join('\n');
-
-    try {
-      const workdir = projectRoot ?? dataContext.project?.fs_storage_mount_path;
-      const { process: agenticProcess } = await AgenticProcess.spawn(
-        { workdir },
-        { instruction: prompt, visible: true },
-      );
-      navigation.openDock(agenticProcess.dockPointer);
-    } catch (err) {
-      console.error('[Claude It] Failed to spawn process:', err);
-    }
-  };
 
   return (
     <div className="flex h-full w-full flex-col bg-card">
@@ -101,25 +73,6 @@ export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
           )}
         </section>
 
-        {/* Claude It + Choose Project */}
-        <div className="flex gap-1">
-          <button
-            onClick={() => void handleClaudeIt()}
-            className="flex flex-[19] items-center justify-center gap-2 rounded-lg border border-primary/40 bg-primary/5 px-4 py-2.5 text-sm font-medium text-primary transition-colors hover:bg-primary/10"
-          >
-            <Sparkles className="h-4 w-4" />
-            Execute the task with Claude Code
-          </button>
-          <button
-            onClick={() => setProjectPickerOpen(true)}
-            title="Choose project folder"
-            className="flex flex-[4] items-center justify-center gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <FolderOpen className="h-4 w-4 shrink-0" />
-            Choose Project
-          </button>
-        </div>
-
         {/* Conversation */}
         <section>
           <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -131,6 +84,7 @@ export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
               conversationId={task.conversation_id}
               task={task}
               senderName={senderName}
+              onChooseProject={() => setProjectPickerOpen(true)}
             />
           ) : (
             <p className="text-xs italic text-muted-foreground/60">No conversation yet.</p>

--- a/ui/src/components/task-bar/SharedTaskView.tsx
+++ b/ui/src/components/task-bar/SharedTaskView.tsx
@@ -5,11 +5,14 @@
  * Replaces the sliding TaskDetailPanel for spec_id tasks.
  */
 
-import { ArrowLeft, MessageSquare } from 'lucide-react';
-import { Spec, Task, TypeId } from '@sdk';
+import { useState } from 'react';
+import { ArrowLeft, FolderOpen, MessageSquare, Sparkles } from 'lucide-react';
+import { AgenticProcess, dataContext, Spec, Task, TypeId } from '@sdk';
 import { useEntity } from '@sdk/react/hooks';
 import { ExpansionRequest } from '@sdk/FlowSync/query';
+import { useDockNavigation } from '@src/navigation/useDockNavigation';
 import { ConversationView } from '@src/components/conversation';
+import { OpenProjectComponent } from '@src/components/open-project-component/open-project-component';
 
 interface SharedTaskViewProps {
   task: Task;
@@ -17,6 +20,9 @@ interface SharedTaskViewProps {
 }
 
 export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
+  const { navigation } = useDockNavigation();
+  const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+
   const blobExpansion = new ExpansionRequest({ expand: ['blobs'] });
 
   const taskMeta = task.metadata as Record<string, unknown> | undefined;
@@ -29,6 +35,31 @@ export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
     task.spec_id ? new TypeId(Spec.type, task.spec_id) : null,
     { query: blobExpansion },
   );
+
+  const handleClaudeIt = async () => {
+    const specContent = spec?.content ?? '';
+    const specTitle = spec?.title ?? task.title ?? 'Untitled';
+    const prompt = [
+      `You received a task from ${senderName}: "${specTitle}"`,
+      '',
+      specContent
+        ? `Here is the plan:\n\n${specContent}`
+        : `Task: ${task.title || 'Untitled'}`,
+      '',
+      'Please read through the plan carefully and confirm you have everything you need to get started. If anything is unclear or missing, ask before proceeding.',
+    ].join('\n');
+
+    try {
+      const workdir = projectRoot ?? dataContext.project?.fs_storage_mount_path;
+      const { process: agenticProcess } = await AgenticProcess.spawn(
+        { workdir },
+        { instruction: prompt, visible: true },
+      );
+      navigation.openDock(agenticProcess.dockPointer);
+    } catch (err) {
+      console.error('[Claude It] Failed to spawn process:', err);
+    }
+  };
 
   return (
     <div className="flex h-full w-full flex-col bg-card">
@@ -70,6 +101,25 @@ export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
           )}
         </section>
 
+        {/* Claude It + Choose Project */}
+        <div className="flex gap-1">
+          <button
+            onClick={() => void handleClaudeIt()}
+            className="flex flex-[19] items-center justify-center gap-2 rounded-lg border border-primary/40 bg-primary/5 px-4 py-2.5 text-sm font-medium text-primary transition-colors hover:bg-primary/10"
+          >
+            <Sparkles className="h-4 w-4" />
+            Execute the task with Claude Code
+          </button>
+          <button
+            onClick={() => setProjectPickerOpen(true)}
+            title="Choose project folder"
+            className="flex flex-[4] items-center justify-center gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <FolderOpen className="h-4 w-4 shrink-0" />
+            Choose Project
+          </button>
+        </div>
+
         {/* Conversation */}
         <section>
           <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -88,6 +138,10 @@ export function SharedTaskView({ task, onClose }: SharedTaskViewProps) {
         </section>
       </div>
 
+      <OpenProjectComponent
+        open={projectPickerOpen}
+        onOpenChange={setProjectPickerOpen}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **`.flowmsg` bundle format**: pack/unpack zip with spec, task, conversation, flow_message and file attachments; upload/download endpoints
- **Conversation continuity**: merge `conversation.jsonl` on re-upload instead of overwriting, preserving locally-added replies
- **Task metadata preservation**: retain `agentic_*` keys when overwriting a task from a bundle so session resume survives re-uploads
- **Single Claude Code session per task**: three-tier reconnect logic — in-memory cache → reconnect live process via `start()` → resume-spawn only when process is dead; eliminates duplicate sessions and "Session ID already in use" errors
- **UI**: consolidated duplicate "Execute" buttons into one (after messages), file attachment pills with per-file download, sender-datetime `.flowmsg` filename, `refetch()` re-render fix in `useEntity`
- **Choose Project** button moved alongside the single execute button

## Test plan

- [ ] Upload a `.flowmsg` bundle — conversation history shown correctly
- [ ] Reply to a task, re-upload the bundle — reply is preserved (not overwritten)
- [ ] Click Execute → one Claude Code session opens
- [ ] Refresh page, click Execute again → reconnects to same session (no second terminal)
- [ ] Upload bundle again, click Execute → still same session, no "Session ID already in use"
- [ ] File attachments appear as named pills with download icon
- [ ] `.flowmsg` download filename is `<sender>-<datetime>.flowmsg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)