### PR TITLE
FLOWPAD-1841: Fix overwrite flag, restore inner FM conflict detection, fix test data

### DIFF
--- a/flow_sdk/app/actions/flow_message_action.py
+++ b/flow_sdk/app/actions/flow_message_action.py
@@ -202,7 +202,8 @@ async def upload_flow_message() -> ApiResponse:
             return ApiFailResponse(message="No file uploaded", status_code=400)
 
         overwrite_qp = request_info.request.query_params.get("overwrite", "false")
-        overwrite = overwrite_qp.lower() in ("true", "1", "yes")
+        overwrite_form = str(post_data.get("overwrite", "false")).lower()
+        overwrite = overwrite_qp.lower() in ("true", "1", "yes") or overwrite_form in ("true", "1", "yes")
         return await handle_upload_flow_message(upload_file, overwrite)
     except Exception as e:
         logger.error(f"[flow_message_action] upload error: {e}", exc_info=True)

--- a/flow_sdk/fs_records/flow_message_bundle.py
+++ b/flow_sdk/fs_records/flow_message_bundle.py
@@ -318,6 +318,7 @@ async def unpack_bundle(
             return _TYPE_ORDER.get(t, 99)
 
         conversation_id: str | None = None
+        task_id: str = ""
         if attachment_dir.exists():
             for entry_dir in sorted(attachment_dir.iterdir(), key=_entry_sort_key):
                 if not entry_dir.is_dir():
@@ -408,12 +409,13 @@ async def unpack_bundle(
                         fm_data.pop("expand", None)
                         fm_id = fm_data.get("id") or entry_id
                         existing_fm = await FlowMessage.get_one({"id": fm_id})
-                        if existing_fm is None or overwrite:
-                            _normalise_attachments(fm_data)
-                            _rewrite_file_attachments(fm_data, tmp_root, task_id or "")
-                            inner_fm = FlowMessage.model_validate(fm_data)
-                            inner_fm.id = fm_id
-                            await inner_fm.save(owner_typeid)
+                        if existing_fm is not None and not overwrite:
+                            raise FlowMessageExistsError([{"type": BuiltinEntityType.FLOW_MESSAGE.value, "id": fm_id}])
+                        _normalise_attachments(fm_data)
+                        _rewrite_file_attachments(fm_data, tmp_root, task_id or "")
+                        inner_fm = FlowMessage.model_validate(fm_data)
+                        inner_fm.id = fm_id
+                        await inner_fm.save(owner_typeid)
 
         # 5. Resolve FILE attachment paths and save the top-level FlowMessage record
         # Bundle stores zip-relative paths; rewrite to absolute paths on this machine.

--- a/tests/api/test_flow_message_actions.py
+++ b/tests/api/test_flow_message_actions.py
@@ -1,7 +1,7 @@
 """Tests for FlowMessage HTTP actions (upload and download).
 
   POST /api/v1/graph/flow-message-upload   — upload .flowmsg (multipart)
-  GET  /api/v1/graph/flow_message/{id}/file-download  — download .flowmsg
+  GET  /api/v1/graph/flow_message/{id}/create-and-download-local-flowmsg  — download .flowmsg
 """
 
 import io
@@ -165,7 +165,7 @@ async def test_download_flow_message_returns_zip(bootstrapped_client):
 
     # Download
     download_resp = await bootstrapped_client.get(
-        f"/api/v1/graph/flow_message/{message_id}/file-download",
+        f"/api/v1/graph/flow_message/{message_id}/create-and-download-local-flowmsg",
     )
     assert download_resp.status_code == 200, (
         f"Expected 200 for download, got {download_resp.status_code}: {download_resp.text}"

--- a/tests/unit/test_flow_message_roundtrip.py
+++ b/tests/unit/test_flow_message_roundtrip.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from flow_sdk.builtin.flow_message import FlowMessage
+from flow_sdk.builtin.flow_message import Attachment, AttachmentType, FlowMessage
 from flow_sdk.fs_records.flow_message_bundle import (
     FlowMessageExistsError,
     pack_bundle,
@@ -27,13 +27,18 @@ from flow_sdk.fs_records.flow_message_bundle import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+_TASK_UUID    = "a1a1a1a1-0000-0000-0000-000000000001"
+_CONV_UUID    = "b2b2b2b2-0000-0000-0000-000000000002"
+_SPEC_UUID    = "c3c3c3c3-0000-0000-0000-000000000003"
+_TASK2_UUID   = "d4d4d4d4-0000-0000-0000-000000000004"
+
+
 def _make_flow_message(fm_id: str = "aaaa1111-0000-0000-0000-000000000001") -> FlowMessage:
     fm = FlowMessage(
         text="Hello, world!",
         instruction="Do something",
-        context=[{"type": "task", "id": "task-id-001"}, {"type": "conversation", "id": "conv-id-001"}],
+        context=[{"type": "task", "id": _TASK_UUID}, {"type": "conversation", "id": _CONV_UUID}],
         attachment=[],
-        sender_id="user-001",
         sender_name="Alice",
         receiver_address="bob@example.com",
         receiver_address_type="email",
@@ -79,7 +84,7 @@ class TestPackBundle:
         """pack_bundle includes attachment/flow_message-@<id>/message.json for flow_message entries."""
         fm = _make_flow_message()
         inner_id = "bbbb2222-0000-0000-0000-000000000002"
-        fm.attachment = [{"type": "flow_message", "id": inner_id}]
+        fm.attachment = [Attachment(attachment_type=AttachmentType.TYPE_ID, data=f"flow_message-{inner_id}")]
 
         inner_fm = FlowMessage(text="inner msg")
         inner_fm.id = inner_id
@@ -98,8 +103,8 @@ class TestPackBundle:
         from flow_sdk.builtin.spec import Spec
 
         fm = _make_flow_message()
-        spec_id = "spec-id-0001"
-        fm.attachment = [{"type": "spec", "id": spec_id}]
+        spec_id = _SPEC_UUID
+        fm.attachment = [Attachment(attachment_type=AttachmentType.TYPE_ID, data=f"spec-{spec_id}")]
 
         mock_spec = Spec(title="My Spec", content="# Content", spec_type="plan")
         mock_spec.id = spec_id
@@ -121,8 +126,8 @@ class TestPackBundle:
         from flow_sdk.builtin.task import Task
 
         fm = _make_flow_message()
-        task_id = "task-id-0001"
-        fm.attachment = [{"type": "task", "id": task_id}]
+        task_id = _TASK2_UUID
+        fm.attachment = [Attachment(attachment_type=AttachmentType.TYPE_ID, data=f"task-{task_id}")]
 
         mock_task = Task(title="My Task")
         mock_task.id = task_id
@@ -258,13 +263,14 @@ class TestUnpackBundle:
         from flow_sdk.builtin.conversation import Conversation
         from flow_sdk.builtin.user import User
 
-        conv_id = "conv-id-9999"
+        conv_id = "cccc9999-0000-0000-0000-000000000009"
+        task_id = "eeee1010-0000-0000-0000-000000000010"
         fm_id = "hhhh8888-0000-0000-0000-000000000008"
         fm_data = {
             "id": fm_id,
             "type": "flow_message",
             "text": "msg with conv",
-            "context": [{"type": "conversation", "id": conv_id}, {"type": "task", "id": "t-001"}],
+            "context": [{"type": "conversation", "id": conv_id}, {"type": "task", "id": task_id}],
             "attachment": [],
         }
         zip_path = _write_flowmsg_zip(tmp_path, fm_data)
@@ -273,12 +279,10 @@ class TestUnpackBundle:
         jsonl_path = tmp_path / "conversation.jsonl"
         jsonl_path.write_text("")
 
-        mock_conv = Conversation(task_id="t-001", data_path=str(jsonl_path))
+        mock_conv = Conversation(task_id=task_id, data_path=str(jsonl_path))
         mock_conv.id = conv_id
 
-        saved_fm = FlowMessage(text="msg with conv")
-        saved_fm.id = fm_id
-        saved_fm.context = fm_data["context"]
+        saved_fm = FlowMessage.model_validate(fm_data)
 
         with (
             patch.object(User, "get_one", new=AsyncMock(return_value=None)),


### PR DESCRIPTION
## Summary
- **Fix `overwrite` silently ignored in bundle upload**: the endpoint was reading `overwrite` only from URL query params, but callers (including the `inbox-open` flow) send it as a multipart form field — now both sources are checked
- **Restore inner FM conflict detection**: `FlowMessageExistsError` was no longer raised for inner FlowMessage attachments in `unpack_bundle`; restored so duplicate uploads correctly 409 (conversation processing still runs first via sort order, so inbox re-fetch is unaffected)
- **Fix test endpoint name**: `test_download_flow_message_returns_zip` was calling the non-existent `/file-download` route instead of `/create-and-download-local-flowmsg`
- **Fix unit test data**: `test_flow_message_roundtrip.py` used non-UUID IDs in `context` (TypeId validator rejects them) and raw dicts instead of `Attachment` model objects

## Test plan
- [ ] `uv run pytest tests/api/test_flow_message_actions.py` — all 4 pass
- [ ] `uv run pytest tests/unit/test_flow_message_roundtrip.py` — all 8 pass
- [ ] Full suite `tests/api/ tests/unit/` — 2051 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)