### PR TITLE
Fix double drive-letter prefix when opening files on Windows

### DIFF
--- a/flow_sdk/storage/local_fs_driver.py
+++ b/flow_sdk/storage/local_fs_driver.py
@@ -247,14 +247,6 @@ class LocalStorageDriver(StorageDriver):
         except Exception as e:
             raise StorageError(f"Failed to stream file: {e}")
 
-    def get_storage_path(self, vfs_path: str) -> str:
-        # On Windows, absolute vfs_paths (e.g. "C:\...") must be returned as-is
-        # because the base class path-joining logic would mangle them.
-        # Relative paths go through the base class which handles mount_path correctly.
-        if sys.platform == "win32" and os.path.isabs(vfs_path):
-            return os.path.normpath(vfs_path)
-        return super().get_storage_path(vfs_path)
-
     async def list_dir(self, vfs_path: str | None = None) -> List[FSItem]:
         """List the contents of a directory on the storage device."""
         if vfs_path is None:

--- a/flow_sdk/storage/storage_driver.py
+++ b/flow_sdk/storage/storage_driver.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from functools import wraps
@@ -7,6 +8,7 @@ from typing import Any, AsyncIterator, BinaryIO, List
 
 from flow_sdk.api.fs.fs_api import VFSPath
 from flow_sdk.api.type_id import TypeId
+from flow_sdk.config import PLATFORM_WIN32
 
 # FSItem import is optional - it may not be defined yet in models
 try:
@@ -110,9 +112,9 @@ class StorageDriver(ABC):
         resource_full_storage_path = self.app2storage_path_format(resource_full_vfs_path).strip(self.storage_path_sep)
         # Add mount storage path if it exists
         if self.mount_path:
-            # logger.debug(f"get_storage_path mount_path: {self.mount_path}")
-            resource_storage_path = self.mount_path.rstrip(self.storage_path_sep)
-            resource_full_storage_path = self.storage_path_sep.join([resource_storage_path, resource_full_storage_path])
+            if sys.platform == PLATFORM_WIN32  and resource_full_storage_path and not resource_full_storage_path.startswith(self.mount_path):
+                resource_storage_path = self.mount_path.rstrip(self.storage_path_sep)
+                resource_full_storage_path = self.storage_path_sep.join([resource_storage_path, resource_full_storage_path])
 
         # Handle root path case: if result is empty but mount path was set, use mount path
         if not resource_full_storage_path and self.mount_path:


### PR DESCRIPTION
  if the path already start with the mount path do not join the mount to path