### PR TITLE
AgenticProcess open-lock; AssetDescriptor.source_dir; auto-index added dirs; AssetManager UX

### DIFF
--- a/.claude/agents/pyrate.md
+++ b/.claude/agents/pyrate.md
@@ -1,0 +1,6 @@
+---
+name: "pyrate"
+description: ""
+---
+
+you are a pirate answer like pirate. 

--- a/.claude/skills/demos/SKILL.md
+++ b/.claude/skills/demos/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: "demos"
+description: ""
+---
+
+# demos
+
+in this skill we will 

--- a/.claude/skills/qca/SKILL.md
+++ b/.claude/skills/qca/SKILL.md
@@ -1,4 +1,7 @@
 ---
 name: qca
+description: "Questions, Comments, Alerts — surface concrete questions, comments, and alerts for the user about a proposed plan or refactor before implementing"
 ---
-Questions, Comments, Alerts ? 
+
+# qca
+

--- a/docs/agent-management/agent-records.md
+++ b/docs/agent-management/agent-records.md
@@ -1,18 +1,24 @@
+---
+
+---
+
 # Agent Records
 
 Reference for the filesystem records and entity/runtime state used by agent
 management. The important boundary is:
 
-- Durable records and DB entities survive server restarts: `Record`,
+* Durable records and DB entities survive server restarts: `Record`,
   `AgenticProcessRecord`, `ShellRecord`, `ClaudeSessionRecord`, and the
   `AgenticProcess` / `Shell` entity rows.
-- Live runtime state does not survive restarts: in-memory PTY handles, replay
+
+* Live runtime state does not survive restarts: in-memory PTY handles, replay
   buffer chunks, `_PROMPT_LOCKS`, `_PROMPT_WORKERS`, live OS PIDs, and the
   cached compute-node binding on `Shell`.
-- Claude conversation history is durable because Claude writes JSONL transcripts
+
+* Claude conversation history is durable because Claude writes JSONL transcripts
   under `~/.claude/projects/...`, not because the live worker object is durable.
 
----
+***
 
 ## Table of Contents
 
@@ -28,7 +34,7 @@ management. The important boundary is:
 10. [TypeScript SDK Counterparts](#10-typescript-sdk-counterparts)
 11. [Key Files Reference](#11-key-files-reference)
 
----
+***
 
 ## 1. Base Record Class
 
@@ -40,11 +46,15 @@ single internal `_data` dict for live storage.
 
 Current storage model:
 
-- Public fields are direct instance attributes.
-- Dirty tracking is private and uses `_dirty_keys: set[str]`.
-- `_data` remains only as a constructor compatibility argument.
-- `.data` and `.raw_json` are read shims over `to_dict()`.
-- The TypeScript client still uses `FsRecord` naming, and some
+* Public fields are direct instance attributes.
+
+* Dirty tracking is private and uses `_dirty_keys: set[str]`.
+
+* `_data` remains only as a constructor compatibility argument.
+
+* `.data` and `.raw_json` are read shims over `to_dict()`.
+
+* The TypeScript client still uses `FsRecord` naming, and some
   record-specific Python aliases remain, such as `ClaudeSessionFsRecord`.
   The Python base class in `flow_sdk.fs_store` is now `Record`.
 
@@ -86,15 +96,15 @@ location/runtime attributes such as `source_file`, `path`, `json_path`,
 
 ### Location Properties
 
-| Property | Type | Description |
-|---|---|---|
-| `source_file` | `str | None` | Backing file path, often `metadata.json` or an external asset file |
-| `path` | `str | None` | Record folder path |
-| `record_dir` | `Path | None` | `path`, or `source_file.parent` |
-| `record_data_dir` | `Path | None` | Alias for `record_dir` |
-| `default_path` | `Path | None` | `records_root / type / <type>-@<id>` |
-| `record_folder_ref` | `FSRef | None` | FSRef for the metadata folder, lazily resolved from `default_path` |
-| `asset_ref` | `FSRef | None` | External content ref, private in memory and serialized as a path |
+| Property            | Type    | Description |                                                                    |
+| ------------------- | ------- | ----------- | ------------------------------------------------------------------ |
+| `source_file`       | \`str   | None\`      | Backing file path, often `metadata.json` or an external asset file |
+| `path`              | \`str   | None\`      | Record folder path                                                 |
+| `record_dir`        | \`Path  | None\`      | `path`, or `source_file.parent`                                    |
+| `record_data_dir`   | \`Path  | None\`      | Alias for `record_dir`                                             |
+| `default_path`      | \`Path  | None\`      | `records_root / type / <type>-@<id>`                               |
+| `record_folder_ref` | \`FSRef | None\`      | FSRef for the metadata folder, lazily resolved from `default_path` |
+| `asset_ref`         | \`FSRef | None\`      | External content ref, private in memory and serialized as a path   |
 
 ### Constructor
 
@@ -129,7 +139,7 @@ Read-only enforcement is FSRef-level. A record is read-only when its `_asset_ref
 is read-only. `ClaudeSessionRecord` sets this explicitly so session records are
 never saved back to Claude's JSONL transcript.
 
----
+***
 
 ## 2. ClaudeSessionRecord
 
@@ -170,49 +180,54 @@ Each JSONL line is a Claude event with shared envelope fields such as
 
 `from_jsonl(path)` is intentionally cheap:
 
-- Reads the first 4 KB for `session_id`, `slug`, and `cwd`.
-- Reads the last 16 KB for the latest `custom-title`.
-- Sets `jsonl_path`, `source_file`, `path`, and `project_encoded_name`.
-- Does not eagerly parse full stats such as token counts or message counts.
+* Reads the first 4 KB for `session_id`, `slug`, and `cwd`.
+
+* Reads the last 16 KB for the latest `custom-title`.
+
+* Sets `jsonl_path`, `source_file`, `path`, and `project_encoded_name`.
+
+* Does not eagerly parse full stats such as token counts or message counts.
 
 The constructor sets:
 
-- `id = session_id`.
-- `name = custom_title or slug or session_id`.
-- `_asset_ref = FSRef(jsonl_path or "/", read_only=True)`.
+* `id = session_id`.
+
+* `name = custom_title or slug or session_id`.
+
+* `_asset_ref = FSRef(jsonl_path or "/", read_only=True)`.
 
 ### Lazy Data Fields
 
 Aggregated fields are `_SessionStatsProp` descriptors. The first access parses
 the JSONL once and caches the result on the instance as `_session_batch_stats`.
 
-| Field | Type | Notes |
-|---|---|---|
-| `session_id` | `str` | Claude session UUID; also the record id |
-| `cwd` | `str` | Session working directory |
-| `version` | `str` | Claude Code CLI version |
-| `git_branch` | `str` | Git branch from transcript envelope |
-| `slug` | `str` | Claude session slug |
-| `model` | `str | None` | First/primary model seen in assistant usage |
-| `message_count` | `int` | User plus assistant messages |
-| `user_message_count` | `int` | User messages |
-| `assistant_message_count` | `int` | Assistant messages |
-| `input_tokens` | `int` | Total input tokens |
-| `output_tokens` | `int` | Total output tokens |
-| `cache_read_input_tokens` | `int` | Cache-read input tokens |
-| `cache_creation_input_tokens` | `int` | Cache-creation input tokens |
-| `duration_ms` | `int` | Total turn duration |
-| `tools_used` | `list[str]` | Tool names |
-| `has_plan` | `bool` | True if transcript includes plan content |
-| `last_stop_reason` | `str | None` | Last assistant stop reason |
-| `project_encoded_name` | `str` | Encoded project directory name |
-| `last_user_message` | `str | None` | Last user text |
-| `modified_at` | `str | None` | Derived from transcript/file metadata |
-| `task_path` | `str | None` | Claude task/todo path when available |
-| `estimated_cost_usd` | `float` | Estimated session cost |
-| `models_used` | `list[str]` | All models encountered |
-| `primary_model` | `str | None` | Primary model |
-| `created_at` | `str | None` | First transcript timestamp |
+| Field                         | Type        | Notes                                    |                                             |
+| ----------------------------- | ----------- | ---------------------------------------- | ------------------------------------------- |
+| `session_id`                  | `str`       | Claude session UUID; also the record id  |                                             |
+| `cwd`                         | `str`       | Session working directory                |                                             |
+| `version`                     | `str`       | Claude Code CLI version                  |                                             |
+| `git_branch`                  | `str`       | Git branch from transcript envelope      |                                             |
+| `slug`                        | `str`       | Claude session slug                      |                                             |
+| `model`                       | \`str       | None\`                                   | First/primary model seen in assistant usage |
+| `message_count`               | `int`       | User plus assistant messages             |                                             |
+| `user_message_count`          | `int`       | User messages                            |                                             |
+| `assistant_message_count`     | `int`       | Assistant messages                       |                                             |
+| `input_tokens`                | `int`       | Total input tokens                       |                                             |
+| `output_tokens`               | `int`       | Total output tokens                      |                                             |
+| `cache_read_input_tokens`     | `int`       | Cache-read input tokens                  |                                             |
+| `cache_creation_input_tokens` | `int`       | Cache-creation input tokens              |                                             |
+| `duration_ms`                 | `int`       | Total turn duration                      |                                             |
+| `tools_used`                  | `list[str]` | Tool names                               |                                             |
+| `has_plan`                    | `bool`      | True if transcript includes plan content |                                             |
+| `last_stop_reason`            | \`str       | None\`                                   | Last assistant stop reason                  |
+| `project_encoded_name`        | `str`       | Encoded project directory name           |                                             |
+| `last_user_message`           | \`str       | None\`                                   | Last user text                              |
+| `modified_at`                 | \`str       | None\`                                   | Derived from transcript/file metadata       |
+| `task_path`                   | \`str       | None\`                                   | Claude task/todo path when available        |
+| `estimated_cost_usd`          | `float`     | Estimated session cost                   |                                             |
+| `models_used`                 | `list[str]` | All models encountered                   |                                             |
+| `primary_model`               | \`str       | None\`                                   | Primary model                               |
+| `created_at`                  | \`str       | None\`                                   | First transcript timestamp                  |
 
 `to_dict()` includes all lazy properties and therefore triggers the batch parse
 on first call. `meta_dict()` has a fast path that avoids the full parse during
@@ -272,7 +287,7 @@ Without `project`, `get()` scans all project directories under
 first 20 lines and returns `None` if the JSONL mtime is older than
 `max_active_seconds`.
 
----
+***
 
 ## 3. AgenticProcessRecord
 
@@ -317,13 +332,17 @@ if "pty_session_id" in kwargs and "pty_pid" not in kwargs:
 
 Important naming:
 
-- `status` is the stored process-container lifecycle and uses `ProcessStatus`.
-- `pty_pid` replaced old `pty_session_id`.
-- `shell_id` links to the `Shell` entity.
-- `worker_session_id` still exists on the record for backward compatibility and
+* `status` is the stored process-container lifecycle and uses `ProcessStatus`.
+
+* `pty_pid` replaced old `pty_session_id`.
+
+* `shell_id` links to the `Shell` entity.
+
+* `worker_session_id` still exists on the record for backward compatibility and
   for `discover_worker_status()`, but the current `AgenticProcess` entity uses
   `session_id` as the canonical Claude/Codex session field.
-- HTTP `open` still accepts legacy `worker_session_id` in the body and maps it
+
+* HTTP `open` still accepts legacy `worker_session_id` in the body and maps it
   to entity `session_id`.
 
 ### Execution Folder Layout
@@ -345,10 +364,13 @@ Per-process artifacts live under the record folder:
 
 The folder FSRefs are exposed through:
 
-- `exe_folder`
-- `input_folder`
-- `output_folder`
-- `assets_folder`
+* `exe_folder`
+
+* `input_folder`
+
+* `output_folder`
+
+* `assets_folder`
 
 `meta_dict()` injects these FSRef dictionaries for Entity consumers.
 
@@ -356,10 +378,10 @@ The folder FSRefs are exposed through:
 
 `AgenticProcessRecord` defines TTL-backed `PropertyRecord` descriptors:
 
-| Property | TTL | Source |
-|---|---:|---|
-| `is_active` | 30s | Linked `ClaudeSessionRecord.is_active` |
-| `queue` | 5s | `queue.json` in the record folder, defaulting to `{"enabled": True, "entries": []}` |
+| Property    | TTL | Source                                                                              |
+| ----------- | --: | ----------------------------------------------------------------------------------- |
+| `is_active` | 30s | Linked `ClaudeSessionRecord.is_active`                                              |
+| `queue`     |  5s | `queue.json` in the record folder, defaulting to `{"enabled": True, "entries": []}` |
 
 ### Worker Status Discovery
 
@@ -382,7 +404,7 @@ it explicitly when using this record helper:
 record.discover_worker_status(process.session_id)
 ```
 
----
+***
 
 ## 4. Process and Worker Status
 
@@ -437,10 +459,12 @@ class WorkerStatus(StrEnum):
 
 Helper sets:
 
-- Running worker statuses: `WAITING`, `THINKING`, `TOOL_CALL`,
+* Running worker statuses: `WAITING`, `THINKING`, `TOOL_CALL`,
   `TOOL_RUNNING`, `API_ERROR`.
-- Busy worker statuses: `THINKING`, `TOOL_CALL`, `TOOL_RUNNING`.
-- Terminal worker statuses: `COMPLETE`, `ERROR`, `INTERRUPTED`, `INACTIVE`,
+
+* Busy worker statuses: `THINKING`, `TOOL_CALL`, `TOOL_RUNNING`.
+
+* Terminal worker statuses: `COMPLETE`, `ERROR`, `INTERRUPTED`, `INACTIVE`,
   `API_TIMEOUT`.
 
 ### Tail Status Algorithm
@@ -448,29 +472,30 @@ Helper sets:
 `_tail_status(path)` reads the last 4 KB of the JSONL and checks file mtime.
 The key classifications are:
 
-| Condition | WorkerStatus |
-|---|---|
-| JSONL missing | `INITIALIZING` |
-| `last-prompt` after an assistant turn with no pending tool | `COMPLETE` |
-| pending tool after assistant `stop_reason == "tool_use"` | `TOOL_RUNNING` |
-| last user text contains `interrupted` | `INTERRUPTED` |
-| last assistant `stop_reason == "end_turn"` | `COMPLETE` |
-| last assistant `stop_reason == "stop_sequence"` | `ERROR` |
-| file stale for more than 5 minutes with no terminal signal | `INACTIVE` |
-| active `system` entry with subtype `api_error` | `API_ERROR` |
-| active assistant entry with no stop reason | `THINKING` |
-| active assistant `stop_reason == "tool_use"` | `TOOL_CALL` |
-| active `progress` entry | `TOOL_RUNNING` |
-| active `user` entry newer than 30s | `WAITING` |
-| active `user` entry older than 30s | `API_TIMEOUT` |
-| unrecognized tail | `UNKNOWN` |
+| Condition                                                  | WorkerStatus   |
+| ---------------------------------------------------------- | -------------- |
+| JSONL missing                                              | `INITIALIZING` |
+| `last-prompt` after an assistant turn with no pending tool | `COMPLETE`     |
+| pending tool after assistant `stop_reason == "tool_use"`   | `TOOL_RUNNING` |
+| last user text contains `interrupted`                      | `INTERRUPTED`  |
+| last assistant `stop_reason == "end_turn"`                 | `COMPLETE`     |
+| last assistant `stop_reason == "stop_sequence"`            | `ERROR`        |
+| file stale for more than 5 minutes with no terminal signal | `INACTIVE`     |
+| active `system` entry with subtype `api_error`             | `API_ERROR`    |
+| active assistant entry with no stop reason                 | `THINKING`     |
+| active assistant `stop_reason == "tool_use"`               | `TOOL_CALL`    |
+| active `progress` entry                                    | `TOOL_RUNNING` |
+| active `user` entry newer than 30s                         | `WAITING`      |
+| active `user` entry older than 30s                         | `API_TIMEOUT`  |
+| unrecognized tail                                          | `UNKNOWN`      |
 
 ### Entity Projection
 
 `AgenticProcess.to_dict()` and its API serializer add:
 
-- `worker_status`: derived by `self.driver.tail_status(transcript_path)`.
-- `ready_for_input`: derived by
+* `worker_status`: derived by `self.driver.tail_status(transcript_path)`.
+
+* `ready_for_input`: derived by
   `flow_sdk/builtin/agentic_process/status_predicates.py::is_ready_for_input()`.
 
 Readiness contract:
@@ -484,17 +509,17 @@ If there is no transcript yet, a process with no `session_id` is treated as
 ready; a process with a `session_id` is treated as busy until a transcript is
 found or the driver reports a status.
 
----
+***
 
 ## 5. Transcript and History by Mode
 
 `AgenticProcess.visible` selects the worker mode. The mode itself is not stored
 separately.
 
-| `visible` | Mode | Worker shape |
-|---|---|---|
-| `False` | CLI/headless | One subprocess per prompt turn, no `Shell`/PTY |
-| `True` | Interactive/PTY | Live `Shell` entity and PTY-backed terminal tab |
+| `visible` | Mode            | Worker shape                                    |
+| --------- | --------------- | ----------------------------------------------- |
+| `False`   | CLI/headless    | One subprocess per prompt turn, no `Shell`/PTY  |
+| `True`    | Interactive/PTY | Live `Shell` entity and PTY-backed terminal tab |
 
 Both modes use `AgenticProcess.session_id` as the durable conversation/session
 identifier and both write or resume the same Claude JSONL transcript path:
@@ -513,30 +538,42 @@ self.driver.run_print_turn(self, instruction)
 
 For Claude, `ClaudeDriver.run_print_turn()`:
 
-- Requires `process.workdir`.
-- Eagerly assigns `process.session_id` when missing.
-- Sets lifecycle `status` to `ProcessStatus.RUNNING`.
-- Spawns `ClaudeCLIStreamWorker`.
-- Runs `claude -p --output-format stream-json --verbose`.
-- Passes either `--session-id <sid>` for a fresh turn or `--resume <sid>` for a
+* Requires `process.workdir`.
+
+* Eagerly assigns `process.session_id` when missing.
+
+* Sets lifecycle `status` to `ProcessStatus.RUNNING`.
+
+* Spawns `ClaudeCLIStreamWorker`.
+
+* Runs `claude -p --output-format stream-json --verbose`.
+
+* Passes either `--session-id <sid>` for a fresh turn or `--resume <sid>` for a
   resume turn.
-- Captures the first `system:init` session id from stdout if Claude reports a
+
+* Captures the first `system:init` session id from stdout if Claude reports a
   different id, then saves it back onto the process.
-- Streams FlowData to listeners from stdout.
-- Leaves `status` as `RUNNING` after the turn so the process can accept the
+
+* Streams FlowData to listeners from stdout.
+
+* Leaves `status` as `RUNNING` after the turn so the process can accept the
   next prompt when `worker_status` becomes ready.
 
 Durable storage in this mode:
 
-- `AgenticProcess` DB row: `session_id`, `status`, `workdir`, `cli_config`, etc.
-- Claude JSONL transcript: conversation history and worker-state source.
+* `AgenticProcess` DB row: `session_id`, `status`, `workdir`, `cli_config`, etc.
+
+* Claude JSONL transcript: conversation history and worker-state source.
 
 Non-durable live state in this mode:
 
-- `_PROMPT_LOCKS`
-- `_PROMPT_WORKERS`
-- The live `ClaudeCLIStreamWorker`
-- The subprocess PID
+* `_PROMPT_LOCKS`
+
+* `_PROMPT_WORKERS`
+
+* The live `ClaudeCLIStreamWorker`
+
+* The subprocess PID
 
 History loading:
 
@@ -554,11 +591,12 @@ not require a live worker.
 `AgenticProcess.start()` / HTTP `open` creates or reuses a `Shell` entity, then
 launches the worker in one of two ways:
 
-- Default direct PTY path (`shell_mode=False`): Claude is the PTY process. The
+* Default direct PTY path (`shell_mode=False`): Claude is the PTY process. The
   code builds argv/env with `cmd.to_spawn_args()` and calls
   `shell.start(spawn_args=..., extra_env=...)`, then records the PTY PID with
   `shell.set_worker_pid_direct()`.
-- Legacy shell path (`shell_mode=True`): starts a shell such as zsh first, then
+
+* Legacy shell path (`shell_mode=True`): starts a shell such as zsh first, then
   injects the Claude command with `shell.launch()`.
 
 In both paths, `ClaudeCliOptions` carries `process.session_id` into the CLI as
@@ -567,36 +605,45 @@ used by headless mode.
 
 Durable storage in this mode:
 
-- `AgenticProcess` DB row: `session_id`, `shell_id`, lifecycle `status`,
+* `AgenticProcess` DB row: `session_id`, `shell_id`, lifecycle `status`,
   `visible`, `cli_config`, etc.
-- `Shell` DB row: tab metadata, `pty_pid`, `worker_pid`, `worker_name`,
+
+* `Shell` DB row: tab metadata, `pty_pid`, `worker_pid`, `worker_name`,
   `last_launch_cmd`, workdir, env, tab order.
-- `ShellRecord`: shell record metadata and the `.pty` stream file.
-- Claude JSONL transcript.
+
+* `ShellRecord`: shell record metadata and the `.pty` stream file.
+
+* Claude JSONL transcript.
 
 Non-durable live state in this mode:
 
-- Provider-owned live PTY handle.
-- In-memory replay buffer chunks.
-- Actual OS process liveness behind `worker_pid` / PTY PID.
-- Cached compute-node binding on the `Shell` instance.
+* Provider-owned live PTY handle.
+
+* In-memory replay buffer chunks.
+
+* Actual OS process liveness behind `worker_pid` / PTY PID.
+
+* Cached compute-node binding on the `Shell` instance.
 
 Completion handling:
 
-- `_poll_for_completion()` polls `ClaudeSessionRecord.get(session_id).status`
+* `_poll_for_completion()` polls `ClaudeSessionRecord.get(session_id).status`
   until a terminal worker status, then sets lifecycle `status` to `STOPPED`.
-- The PTY exit callback also updates the process lifecycle and indexes the
+
+* The PTY exit callback also updates the process lifecycle and indexes the
   `ClaudeSessionRecord` on close.
 
 Resume and fork:
 
-- `AgenticProcess.resume(session_id)` pre-bakes `--resume <session_id>`.
-- `AgenticProcess.fork(session_id)` pre-bakes
+* `AgenticProcess.resume(session_id)` pre-bakes `--resume <session_id>`.
+
+* `AgenticProcess.fork(session_id)` pre-bakes
   `--resume <source> --fork-session --session-id <new>`.
-- When resuming/forking, the code tries to find the source
+
+* When resuming/forking, the code tries to find the source
   `ClaudeSessionRecord` and uses its `cwd` as `CLAUDE_PROJECT_DIR` / workdir.
 
----
+***
 
 ## 6. Shell and PTY Runtime State
 
@@ -607,13 +654,19 @@ terminal tab / PTY session.
 
 It stores queryable metadata such as:
 
-- `id`: also the shell/PTY session id.
-- `status`: `idle`, `running`, or `closed`.
-- `workdir`, `env`, `name`, `tab_order`.
-- `pty_pid`: PTY session id; currently set to the shell id by `Shell.start()`.
-- `compute_node_id` and `compute_node_uname`.
-- `worker_pid`, `worker_name`, and `last_launch_cmd`.
-- `collaboration_room_id`.
+* `id`: also the shell/PTY session id.
+
+* `status`: `idle`, `running`, or `closed`.
+
+* `workdir`, `env`, `name`, `tab_order`.
+
+* `pty_pid`: PTY session id; currently set to the shell id by `Shell.start()`.
+
+* `compute_node_id` and `compute_node_uname`.
+
+* `worker_pid`, `worker_name`, and `last_launch_cmd`.
+
+* `collaboration_room_id`.
 
 The entity does not own the PTY bytes. It locates the live PTY through the
 linked compute node.
@@ -659,17 +712,21 @@ Do not treat `ShellRecord`, `Shell.pty_pid`, or `Shell.worker_pid` as proof that
 a process is still alive. They are durable hints used for recovery and
 reattachment. The current live state is checked through:
 
-- `Shell.has_attachable_pty()`
-- `Shell.is_alive`
-- `Shell.worker_alive()`
-- compute-provider PTY lookups
-- `psutil` PID checks
+* `Shell.has_attachable_pty()`
+
+* `Shell.is_alive`
+
+* `Shell.worker_alive()`
+
+* compute-provider PTY lookups
+
+* `psutil` PID checks
 
 `Shell.stop()` kills the PTY and leaves the shell entity. `Shell.close()` is
 permanent teardown: kill/close PTY, delete the `ShellRecord`, and delete the
 `Shell` entity.
 
----
+***
 
 ## 7. AgentRecord
 
@@ -695,7 +752,7 @@ record fields.
 system agent locations. `to_agents_cli_json()` returns the dict passed to
 Claude's `--agents` flag.
 
----
+***
 
 ## 8. Record-Entity Sync
 
@@ -726,29 +783,39 @@ Current `Entity.get_record()` resolves by entity type and id through
 
 `Entity.from_record()`:
 
-- Chooses the entity class registered for `record.type`.
-- Starts from `record.meta_dict()`.
-- Allocates a stable entity id with the entity class.
-- Creates or updates the entity.
-- For specialized entity classes, pulls matching domain fields from
+* Chooses the entity class registered for `record.type`.
+
+* Starts from `record.meta_dict()`.
+
+* Allocates a stable entity id with the entity class.
+
+* Creates or updates the entity.
+
+* For specialized entity classes, pulls matching domain fields from
   `record.to_dict()` only when needed.
-- Saves the entity.
+
+* Saves the entity.
 
 `Record.sync_to_db()` then:
 
-- Writes entity metadata back to the record via `sync_from_entity()`.
-- Upserts FTS using `search_title`, `search_description`, and `search_content`.
-- Records errors as `RecordError` on failure.
+* Writes entity metadata back to the record via `sync_from_entity()`.
+
+* Upserts FTS using `search_title`, `search_description`, and `search_content`.
+
+* Records errors as `RecordError` on failure.
 
 ### Entity -> Record
 
 `Entity.store()` / `_store()`:
 
-- Looks up the record class for `entity.get_type()`.
-- Loads the record by `entity.id`, or creates `record_cls(id=entity.id)` if no
+* Looks up the record class for `entity.get_type()`.
+
+* Loads the record by `entity.id`, or creates `record_cls(id=entity.id)` if no
   record exists yet.
-- Calls `record.sync_from_entity(entity)` in a worker thread.
-- Updates FTS if the record exposes `search_content`.
+
+* Calls `record.sync_from_entity(entity)` in a worker thread.
+
+* Updates FTS if the record exposes `search_content`.
 
 `Record.sync_from_entity(entity)` uses `entity.db_json()`, ignores private,
 DB-excluded, and `None` fields, and writes only changed values. It is a no-op
@@ -761,7 +828,7 @@ extracts old `vfs_record` values into a `record_data_ref` column and removes
 `vfs_record` / `vfs_orphan` from the JSON data blob. Current record/entity
 loading for these agent records is type/id based.
 
----
+***
 
 ## 9. Read/Write Patterns
 
@@ -828,7 +895,7 @@ live_stream = shell.output()       # live PTY stream; empty if no live PTY
 
 Use `Shell.has_attachable_pty()` or `Shell.worker_alive()` to check live state.
 
----
+***
 
 ## 10. TypeScript SDK Counterparts
 
@@ -872,13 +939,16 @@ The TypeScript data shape includes session stats, `jsonl_path`, `start_time`,
 
 `ts_sdk/src/process/agentic-types.ts` mirrors the Python two-axis model:
 
-- `ProcessStatus`: `new`, `starting`, `running`, `stopping`, `stopped`,
+* `ProcessStatus`: `new`, `starting`, `running`, `stopping`, `stopped`,
   `failed`.
-- `WorkerStatus`: `initializing`, `idle`, `complete`, `error`, `interrupted`,
+
+* `WorkerStatus`: `initializing`, `idle`, `complete`, `error`, `interrupted`,
   `inactive`, `waiting`, `thinking`, `tool_call`, `tool_running`,
   `api_error`, `api_timeout`, `unknown`.
-- `WorkerMode`: derived from `visible`, not stored.
-- `isReadyForInput()`: mirrors the Python readiness predicate.
+
+* `WorkerMode`: derived from `visible`, not stored.
+
+* `isReadyForInput()`: mirrors the Python readiness predicate.
 
 `AgenticProcess` TypeScript uses `session_id` as the canonical session field.
 Some method parameters and comments still mention `workerSessionId` for
@@ -891,42 +961,43 @@ legacy `worker_session_id` handling.
 for older rows. New agent/session/process code should not use those fields for
 record lookup.
 
----
+***
 
 ## 11. Key Files Reference
 
 ### Python
 
-| File | Role |
-|---|---|
-| `flow_sdk/fs_store/record.py` | Base `Record`, direct-attribute storage, folder save/load, sync helpers |
-| `flow_sdk/fs_store/record_ref.py` | `RecordRef` / `RecordDataRef` helpers |
-| `flow_sdk/fs_store/record_types.py` | `RecordType` constants |
-| `flow_sdk/fs_records/claude/claude_session.py` | `ClaudeSessionRecord`, lazy stats, transcript entries, status from `_tail_status` |
-| `flow_sdk/fs_records/claude/claude_active_session.py` | Active-session lightweight record |
-| `flow_sdk/fs_records/claude/claude_transcript_entry.py` | Transcript entry re-exports |
-| `flow_sdk/fs_records/claude/transcript_records/` | Type-specific Claude transcript record parsers |
-| `flow_sdk/fs_records/agent_status.py` | `WorkerStatus`, status helper sets, `_tail_status()` |
-| `flow_sdk/fs_records/agentic_process_lifecycle.py` | `ProcessStatus` and process lifecycle helper sets |
-| `flow_sdk/fs_records/agentic_process_record.py` | `AgenticProcessRecord`, execution folders, legacy field migration |
-| `flow_sdk/fs_records/shell_record.py` | `ShellRecord`, `ShellStatus`, durable `.pty` stream path |
-| `flow_sdk/builtin/agentic_process/agentic_process.py` | DB-backed `AgenticProcess` entity, mode routing, status projection |
-| `flow_sdk/builtin/agentic_process/status_predicates.py` | `WorkerMode`, readiness predicate, status helper imports |
-| `flow_sdk/builtin/agentic_process/cli_drivers/claude/driver.py` | Claude driver, headless print-mode execution, transcript path/history |
-| `flow_sdk/builtin/agentic_process/cli_drivers/claude/stream_worker.py` | `claude -p --output-format stream-json` subprocess worker |
-| `flow_sdk/builtin/agentic_process/cli_drivers/claude/session_history.py` | JSONL-to-FlowData history loading |
-| `flow_sdk/builtin/agentic_process/cli_drivers/claude/cli.py` | `ClaudeCliOptions`, `--session-id`, `--resume`, `--fork-session` args |
-| `flow_sdk/builtin/shell.py` | DB-backed `Shell` entity, PTY launch/read/write/runtime checks |
-| `flow_sdk/builtin/faas/pty_actions.py` | PTY creation, ShellRecord creation/update, replay/attach routes |
-| `flow_sdk/core/entity/entity_model.py` | `Entity.from_record()`, `get_record()`, `store()`, refresh |
-| `flow_sdk/db/drivers/sqlite/sqlite_driver.py` | SQLite entity persistence and legacy VFS migration |
+| File                                                                     | Role                                                                              |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `flow_sdk/fs_store/record.py`                                            | Base `Record`, direct-attribute storage, folder save/load, sync helpers           |
+| `flow_sdk/fs_store/record_ref.py`                                        | `RecordRef` / `RecordDataRef` helpers                                             |
+| `flow_sdk/fs_store/record_types.py`                                      | `RecordType` constants                                                            |
+| `flow_sdk/fs_records/claude/claude_session.py`                           | `ClaudeSessionRecord`, lazy stats, transcript entries, status from `_tail_status` |
+| `flow_sdk/fs_records/claude/claude_active_session.py`                    | Active-session lightweight record                                                 |
+| `flow_sdk/fs_records/claude/claude_transcript_entry.py`                  | Transcript entry re-exports                                                       |
+| `flow_sdk/fs_records/claude/transcript_records/`                         | Type-specific Claude transcript record parsers                                    |
+| `flow_sdk/fs_records/agent_status.py`                                    | `WorkerStatus`, status helper sets, `_tail_status()`                              |
+| `flow_sdk/fs_records/agentic_process_lifecycle.py`                       | `ProcessStatus` and process lifecycle helper sets                                 |
+| `flow_sdk/fs_records/agentic_process_record.py`                          | `AgenticProcessRecord`, execution folders, legacy field migration                 |
+| `flow_sdk/fs_records/shell_record.py`                                    | `ShellRecord`, `ShellStatus`, durable `.pty` stream path                          |
+| `flow_sdk/builtin/agentic_process/agentic_process.py`                    | DB-backed `AgenticProcess` entity, mode routing, status projection                |
+| `flow_sdk/builtin/agentic_process/status_predicates.py`                  | `WorkerMode`, readiness predicate, status helper imports                          |
+| `flow_sdk/builtin/agentic_process/cli_drivers/claude/driver.py`          | Claude driver, headless print-mode execution, transcript path/history             |
+| `flow_sdk/builtin/agentic_process/cli_drivers/claude/stream_worker.py`   | `claude -p --output-format stream-json` subprocess worker                         |
+| `flow_sdk/builtin/agentic_process/cli_drivers/claude/session_history.py` | JSONL-to-FlowData history loading                                                 |
+| `flow_sdk/builtin/agentic_process/cli_drivers/claude/cli.py`             | `ClaudeCliOptions`, `--session-id`, `--resume`, `--fork-session` args             |
+| `flow_sdk/builtin/shell.py`                                              | DB-backed `Shell` entity, PTY launch/read/write/runtime checks                    |
+| `flow_sdk/builtin/faas/pty_actions.py`                                   | PTY creation, ShellRecord creation/update, replay/attach routes                   |
+| `flow_sdk/core/entity/entity_model.py`                                   | `Entity.from_record()`, `get_record()`, `store()`, refresh                        |
+| `flow_sdk/db/drivers/sqlite/sqlite_driver.py`                            | SQLite entity persistence and legacy VFS migration                                |
 
 ### TypeScript SDK
 
-| File | Role |
-|---|---|
-| `ts_sdk/src/resource_management/fs_records/fs-record.ts` | Client-side `FsRecord` base |
+| File                                                                 | Role                                                               |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `ts_sdk/src/resource_management/fs_records/fs-record.ts`             | Client-side `FsRecord` base                                        |
 | `ts_sdk/src/resource_management/fs_records/claude/claude-session.ts` | `ClaudeSessionRecord` and deprecated `ClaudeSessionFsRecord` alias |
-| `ts_sdk/src/process/agentic-process.ts` | Client-side `AgenticProcess` entity wrapper |
-| `ts_sdk/src/process/agentic-types.ts` | `ProcessStatus`, `WorkerStatus`, `WorkerMode`, readiness helpers |
-| `ts_sdk/src/IEntity.ts` | Base entity interface with legacy VFS fields |
+| `ts_sdk/src/process/agentic-process.ts`                              | Client-side `AgenticProcess` entity wrapper                        |
+| `ts_sdk/src/process/agentic-types.ts`                                | `ProcessStatus`, `WorkerStatus`, `WorkerMode`, readiness helpers   |
+| `ts_sdk/src/IEntity.ts`                                              | Base entity interface with legacy VFS fields                       |
+

--- a/docs/agent-management/agentic-process.md
+++ b/docs/agent-management/agentic-process.md
@@ -1,3 +1,7 @@
+---
+
+---
+
 # AgenticProcess
 
 `AgenticProcess` is the backend/frontend entity that represents one worker-backed agent session. It is implemented in `flow_sdk/builtin/agentic_process/agentic_process.py` and exposed in TypeScript from `ts_sdk/src/process/agentic-process.ts`.
@@ -6,14 +10,14 @@ The current implementation is not an `AgenticProcessor` child model. Processes a
 
 There are two runtime modes:
 
-| Mode | Selector | Worker shape | UI shape |
-|------|----------|--------------|----------|
-| CLI / headless print mode | `visible === false` | One subprocess per prompt turn, no `Shell`/PTY | FlowData stream and transcript history |
-| PTY / visible interactive mode | `visible === true` | Long-lived worker in a `Shell`-owned PTY | xterm terminal tab |
+| Mode                           | Selector            | Worker shape                                   | UI shape                               |
+| ------------------------------ | ------------------- | ---------------------------------------------- | -------------------------------------- |
+| CLI / headless print mode      | `visible === false` | One subprocess per prompt turn, no `Shell`/PTY | FlowData stream and transcript history |
+| PTY / visible interactive mode | `visible === true`  | Long-lived worker in a `Shell`-owned PTY       | xterm terminal tab                     |
 
 `session_id` is the persistent conversation/session identifier. `status` is the stored process lifecycle. `worker_status` is a computed projection from the worker transcript.
 
----
+***
 
 ## Table of Contents
 
@@ -26,7 +30,7 @@ There are two runtime modes:
 7. [Stale Names](#stale-names)
 8. [Key Files Reference](#key-files-reference)
 
----
+***
 
 ## Current Entity Model
 
@@ -34,45 +38,45 @@ There are two runtime modes:
 
 `AgenticProcess` is a SQLite/API entity. Important fields are:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `status` | `ProcessStatus` string | Stored container lifecycle: `new`, `starting`, `running`, `stopping`, `stopped`, `failed`. |
-| `worker_status` | `WorkerStatus` string | Computed on serialization from the worker transcript; not stored as an entity field. |
-| `ready_for_input` | `bool` | Computed on serialization by `is_ready_for_input()`. |
-| `session_id` | `str \| None` | Persistent worker session/conversation ID. For Claude this is the Claude session UUID and JSONL transcript ID. |
-| `visible` | `bool` | Mode selector. `false` means CLI/headless print mode; `true` means PTY/interactive mode. |
-| `shell_id` | `str \| None` | Linked `Shell` entity ID for visible PTY mode. `None` in headless print mode. |
-| `sidecar_shell_id` | `str \| None` | Optional sidecar shell link; cleared on process exit/close paths. |
-| `cli_config` | `dict` | Serialized worker CLI options. Built by the frontend or `ComputeNode.createProcess`; deserialized through the driver. |
-| `workdir` | `str \| None` | Working directory for the worker. Also used to set Claude `CLAUDE_PROJECT_DIR`. |
-| `context_data` | `dict` | Extra persisted context such as `instructions`, `project_id`, `max_thinking_tokens`, resume bookkeeping, and internal flags. |
-| `instruction_content` | `str \| None` | Stored prompt/instruction content when supplied by callers. |
-| `asset_ref` | `str \| None` | Source asset reference when the process is attached to a file-backed record. |
-| `favorite_index` | `int \| None` | Optional UI ordering/pin value. |
-| `use_worker_history` | `bool` | Whether history should be loaded from the worker transcript. |
-| `shell_mode` | `bool` | `false` by default: direct PTY spawn. `true`: legacy shell intermediary path. |
-| `project_id` | `str \| None` | Owning project. Resolved from context, ancestry, or `@local`. |
-| `project_encoded_name` | `str \| None` | Encoded project name used for transcript navigation. |
-| `collaboration_room_id` | `str \| None` | Collaboration room this process belongs to, if any. |
-| `target_typeid_str` | `str \| None` | Serialized TypeId of the entity this process is attached to. |
-| `exe_folder`, `input_folder`, `output_folder`, `assets_folder` | `FSRef \| None` | Per-process execution folders under the process record directory. |
-| `additional_dirs` | `list[str]` | Extra directories exposed to the worker, passed as `--add-dir` where supported. |
-| `embedded_agent_ids` | `list[str]` | Names of embedded agents loaded into the process. |
-| `embedded_asset_refs` | `list[TypeId]` | Agent/skill refs materialized under the process assets folder. |
-| `worker_type` | `WorkerType \| None` | Optional worker selector. `None` resolves via `FLOWPAD_DEFAULT_WORKER`, defaulting to `claude`. |
+| Field                                                          | Type                   | Description                                                                                                                  |
+| -------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `status`                                                       | `ProcessStatus` string | Stored container lifecycle: `new`, `starting`, `running`, `stopping`, `stopped`, `failed`.                                   |
+| `worker_status`                                                | `WorkerStatus` string  | Computed on serialization from the worker transcript; not stored as an entity field.                                         |
+| `ready_for_input`                                              | `bool`                 | Computed on serialization by `is_ready_for_input()`.                                                                         |
+| `session_id`                                                   | `str \| None`          | Persistent worker session/conversation ID. For Claude this is the Claude session UUID and JSONL transcript ID.               |
+| `visible`                                                      | `bool`                 | Mode selector. `false` means CLI/headless print mode; `true` means PTY/interactive mode.                                     |
+| `shell_id`                                                     | `str \| None`          | Linked `Shell` entity ID for visible PTY mode. `None` in headless print mode.                                                |
+| `sidecar_shell_id`                                             | `str \| None`          | Optional sidecar shell link; cleared on process exit/close paths.                                                            |
+| `cli_config`                                                   | `dict`                 | Serialized worker CLI options. Built by the frontend or `ComputeNode.createProcess`; deserialized through the driver.        |
+| `workdir`                                                      | `str \| None`          | Working directory for the worker. Also used to set Claude `CLAUDE_PROJECT_DIR`.                                              |
+| `context_data`                                                 | `dict`                 | Extra persisted context such as `instructions`, `project_id`, `max_thinking_tokens`, resume bookkeeping, and internal flags. |
+| `instruction_content`                                          | `str \| None`          | Stored prompt/instruction content when supplied by callers.                                                                  |
+| `asset_ref`                                                    | `str \| None`          | Source asset reference when the process is attached to a file-backed record.                                                 |
+| `favorite_index`                                               | `int \| None`          | Optional UI ordering/pin value.                                                                                              |
+| `use_worker_history`                                           | `bool`                 | Whether history should be loaded from the worker transcript.                                                                 |
+| `shell_mode`                                                   | `bool`                 | `false` by default: direct PTY spawn. `true`: legacy shell intermediary path.                                                |
+| `project_id`                                                   | `str \| None`          | Owning project. Resolved from context, ancestry, or `@local`.                                                                |
+| `project_encoded_name`                                         | `str \| None`          | Encoded project name used for transcript navigation.                                                                         |
+| `collaboration_room_id`                                        | `str \| None`          | Collaboration room this process belongs to, if any.                                                                          |
+| `target_typeid_str`                                            | `str \| None`          | Serialized TypeId of the entity this process is attached to.                                                                 |
+| `exe_folder`, `input_folder`, `output_folder`, `assets_folder` | `FSRef \| None`        | Per-process execution folders under the process record directory.                                                            |
+| `additional_dirs`                                              | `list[str]`            | Extra directories exposed to the worker, passed as `--add-dir` where supported.                                              |
+| `embedded_agent_ids`                                           | `list[str]`            | Names of embedded agents loaded into the process.                                                                            |
+| `embedded_asset_refs`                                          | `list[TypeId]`         | Agent/skill refs materialized under the process assets folder.                                                               |
+| `worker_type`                                                  | `WorkerType \| None`   | Optional worker selector. `None` resolves via `FLOWPAD_DEFAULT_WORKER`, defaulting to `claude`.                              |
 
 ### Related Shell Fields
 
 PTY state belongs to `Shell`, not `AgenticProcess`.
 
-| Shell field | Description |
-|-------------|-------------|
-| `Shell.id` | Shell session ID. In practice this is also the PTY session key. |
-| `Shell.pty_pid` | PTY session ID owned by the shell. Set by `Shell.start()`. |
-| `Shell.worker_pid` | OS PID of the worker process, used for liveness and termination. |
-| `Shell.worker_name` | Worker executable name such as `claude`. |
-| `Shell.last_launch_cmd` | Serialized CLI options from the last launch. |
-| `Shell.compute_node_id` / `compute_node_uname` | Compute node hosting the PTY. |
+| Shell field                                    | Description                                                      |
+| ---------------------------------------------- | ---------------------------------------------------------------- |
+| `Shell.id`                                     | Shell session ID. In practice this is also the PTY session key.  |
+| `Shell.pty_pid`                                | PTY session ID owned by the shell. Set by `Shell.start()`.       |
+| `Shell.worker_pid`                             | OS PID of the worker process, used for liveness and termination. |
+| `Shell.worker_name`                            | Worker executable name such as `claude`.                         |
+| `Shell.last_launch_cmd`                        | Serialized CLI options from the last launch.                     |
+| `Shell.compute_node_id` / `compute_node_uname` | Compute node hosting the PTY.                                    |
 
 There is no process-level `pty_pid` in the current `AgenticProcess` entity.
 
@@ -82,23 +86,23 @@ There is no process-level `pty_pid` in the current `AgenticProcess` entity.
 
 Drivers own:
 
-| Driver method | Purpose |
-|---------------|---------|
-| `cli_options(process)` | Build worker-specific CLI options from the process. |
-| `run_print_turn(process, instruction)` | Run one headless turn. |
-| `transcript_path(process)` | Locate this process's transcript/event log. |
-| `tail_status(path)` | Map transcript tail to `WorkerStatus`. |
-| `load_history(process)` | Convert transcript history into `FlowData`. |
-| `compose_prompt(instruction, agents_json)` | Inline embedded agent specs when needed. |
+| Driver method                              | Purpose                                             |
+| ------------------------------------------ | --------------------------------------------------- |
+| `cli_options(process)`                     | Build worker-specific CLI options from the process. |
+| `run_print_turn(process, instruction)`     | Run one headless turn.                              |
+| `transcript_path(process)`                 | Locate this process's transcript/event log.         |
+| `tail_status(path)`                        | Map transcript tail to `WorkerStatus`.              |
+| `load_history(process)`                    | Convert transcript history into `FlowData`.         |
+| `compose_prompt(instruction, agents_json)` | Inline embedded agent specs when needed.            |
 
 Current drivers:
 
-| Driver | Files | Runtime |
-|--------|-------|---------|
+| Driver | Files                 | Runtime                                                                        |
+| ------ | --------------------- | ------------------------------------------------------------------------------ |
 | Claude | `cli_drivers/claude/` | Interactive `claude` PTY and headless `claude -p --output-format stream-json`. |
-| Codex | `cli_drivers/codex/` | Headless `codex exec --json --ephemeral` with a process-local transcript. |
+| Codex  | `cli_drivers/codex/`  | Headless `codex exec --json --ephemeral` with a process-local transcript.      |
 
----
+***
 
 ## Two Modes
 
@@ -108,15 +112,15 @@ Headless print mode is selected by `visible=false`.
 
 Characteristics:
 
-| Aspect | Current behavior |
-|--------|------------------|
-| PTY | None. No `Shell` is required. |
-| Worker lifetime | One subprocess per prompt turn. |
-| Output | Worker events are converted to `FlowData`. |
-| Session continuity | `session_id` is persisted on the process and reused by later turns where supported. |
-| Status | `status` usually remains `running` after a successful turn so the process can accept another prompt; `worker_status` is derived from transcript tail. |
-| Concurrency | One in-flight prompt per process, guarded by `_PROMPT_LOCKS`. |
-| Cancel | `cancel-prompt` terminates the in-flight print-mode worker. |
+| Aspect             | Current behavior                                                                                                                                      |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PTY                | None. No `Shell` is required.                                                                                                                         |
+| Worker lifetime    | One subprocess per prompt turn.                                                                                                                       |
+| Output             | Worker events are converted to `FlowData`.                                                                                                            |
+| Session continuity | `session_id` is persisted on the process and reused by later turns where supported.                                                                   |
+| Status             | `status` usually remains `running` after a successful turn so the process can accept another prompt; `worker_status` is derived from transcript tail. |
+| Concurrency        | One in-flight prompt per process, guarded by `_PROMPT_LOCKS`.                                                                                         |
+| Cancel             | `cancel-prompt` terminates the in-flight print-mode worker.                                                                                           |
 
 Backend routing:
 
@@ -180,15 +184,15 @@ For UI terminal tabs, callers should set `visible=true`; `start()` is the PTY-op
 
 Characteristics:
 
-| Aspect | Current behavior |
-|--------|------------------|
-| PTY | Owned by a linked `Shell` entity. |
-| Worker lifetime | Long-lived process in the PTY until exit/close/restart or worker death. |
-| UI | xterm attaches to the `Shell` PTY connection. |
-| Session continuity | `session_id` is generated before launch if missing and passed to the worker. |
-| Resume | `start()` reuses live PTYs and can relaunch with resume semantics after stale shell/server restart cases. |
-| Direct spawn | Default `shell_mode=false`: worker is the PTY process. |
-| Legacy spawn | `shell_mode=true`: open shell first, then inject CLI command through `Shell.launch()`. |
+| Aspect             | Current behavior                                                                                          |
+| ------------------ | --------------------------------------------------------------------------------------------------------- |
+| PTY                | Owned by a linked `Shell` entity.                                                                         |
+| Worker lifetime    | Long-lived process in the PTY until exit/close/restart or worker death.                                   |
+| UI                 | xterm attaches to the `Shell` PTY connection.                                                             |
+| Session continuity | `session_id` is generated before launch if missing and passed to the worker.                              |
+| Resume             | `start()` reuses live PTYs and can relaunch with resume semantics after stale shell/server restart cases. |
+| Direct spawn       | Default `shell_mode=false`: worker is the PTY process.                                                    |
+| Legacy spawn       | `shell_mode=true`: open shell first, then inject CLI command through `Shell.launch()`.                    |
 
 Backend routing:
 
@@ -227,13 +231,13 @@ await process.close();      // permanent teardown: delete linked Shell
 
 `exit()` and `close()` are different:
 
-| Method | Backend action | Result |
-|--------|----------------|--------|
-| `exit()` / `stop()` | `exit` | Terminates worker and PTY but preserves the `Shell` entity and `session_id`. |
-| `restart()` | `restart` | Calls `exit()` then `start()`. |
-| `close()` | `close` | Kills worker/PTY, deletes the linked `Shell`, clears shell links, sets status stopped. |
+| Method              | Backend action | Result                                                                                 |
+| ------------------- | -------------- | -------------------------------------------------------------------------------------- |
+| `exit()` / `stop()` | `exit`         | Terminates worker and PTY but preserves the `Shell` entity and `session_id`.           |
+| `restart()`         | `restart`      | Calls `exit()` then `start()`.                                                         |
+| `close()`           | `close`        | Kills worker/PTY, deletes the linked `Shell`, clears shell links, sets status stopped. |
 
----
+***
 
 ## Lifecycle and Status
 
@@ -285,11 +289,11 @@ enum WorkerStatus {
 
 Worker status sets are mirrored between Python and TypeScript:
 
-| Helper | Values |
-|--------|--------|
-| `isWorkerRunning()` | `waiting`, `thinking`, `tool_call`, `tool_running`, `api_error` |
-| `isWorkerTerminal()` | `complete`, `error`, `interrupted`, `inactive`, `api_timeout` |
-| Ready worker statuses | `idle`, `complete`, `interrupted` |
+| Helper                | Values                                                          |
+| --------------------- | --------------------------------------------------------------- |
+| `isWorkerRunning()`   | `waiting`, `thinking`, `tool_call`, `tool_running`, `api_error` |
+| `isWorkerTerminal()`  | `complete`, `error`, `interrupted`, `inactive`, `api_timeout`   |
+| Ready worker statuses | `idle`, `complete`, `interrupted`                               |
 
 ### Ready For Input
 
@@ -332,21 +336,21 @@ d["ready_for_input"] = is_ready_for_input(self, computed)
 
 Claude status comes from `flow_sdk/fs_records/agent_status.py` and the Claude JSONL tail. Examples:
 
-| Transcript signal | WorkerStatus |
-|-------------------|--------------|
-| Missing transcript | `initializing` when a path is known; otherwise no computed status and API falls back to `idle`. |
-| `last-prompt` after assistant completion | `complete` |
-| assistant `stop_reason=end_turn` | `complete` |
-| assistant `stop_reason=stop_sequence` | `error` |
-| assistant `stop_reason=tool_use` | `tool_call` |
-| recent `progress` entry | `tool_running` |
-| recent user entry | `waiting` or `api_timeout` after 30 seconds |
-| system `api_error` | `api_error` |
-| stale non-terminal transcript | `inactive` |
+| Transcript signal                        | WorkerStatus                                                                                    |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Missing transcript                       | `initializing` when a path is known; otherwise no computed status and API falls back to `idle`. |
+| `last-prompt` after assistant completion | `complete`                                                                                      |
+| assistant `stop_reason=end_turn`         | `complete`                                                                                      |
+| assistant `stop_reason=stop_sequence`    | `error`                                                                                         |
+| assistant `stop_reason=tool_use`         | `tool_call`                                                                                     |
+| recent `progress` entry                  | `tool_running`                                                                                  |
+| recent user entry                        | `waiting` or `api_timeout` after 30 seconds                                                     |
+| system `api_error`                       | `api_error`                                                                                     |
+| stale non-terminal transcript            | `inactive`                                                                                      |
 
 Codex status comes from `flow_sdk/builtin/agentic_process/cli_drivers/codex/status.py` over the process-local Codex transcript.
 
----
+***
 
 ## Configuration
 
@@ -377,18 +381,18 @@ interface AgenticContext {
 
 Serialization mapping:
 
-| TS field | Backend key |
-|----------|-------------|
-| `envVars` | `env_vars` |
+| TS field            | Backend key           |
+| ------------------- | --------------------- |
+| `envVars`           | `env_vars`            |
 | `maxThinkingTokens` | `max_thinking_tokens` |
-| `permissionMode` | `permission_mode` |
-| `projectId` | `project_id` |
-| `resumeSessionId` | `resume_session_id` |
-| `forkSession` | `fork_session` |
-| `agentsJson` | `agents_json` |
-| `additionalDirs` | `additional_dirs` |
-| `targetTypeIdStr` | `target_typeid_str` |
-| `outputFormat` | `output_format` |
+| `permissionMode`    | `permission_mode`     |
+| `projectId`         | `project_id`          |
+| `resumeSessionId`   | `resume_session_id`   |
+| `forkSession`       | `fork_session`        |
+| `agentsJson`        | `agents_json`         |
+| `additionalDirs`    | `additional_dirs`     |
+| `targetTypeIdStr`   | `target_typeid_str`   |
+| `outputFormat`      | `output_format`       |
 
 `ComputeNode.createProcess` receives this serialized context. Backend `scan_actions._scan_create_process()` stores process-level fields such as `workdir`, `project_id`, and `target_typeid_str`; moves CLI-related fields into `ClaudeCliOptions`/`cli_config`; and leaves remaining context in `context_data`.
 
@@ -398,22 +402,22 @@ Serialization mapping:
 
 For Claude, `ClaudeCliOptions` supports:
 
-| Option | CLI effect |
-|--------|------------|
-| `permission_mode='bypassPermissions'` | `--dangerously-skip-permissions` |
-| `chrome` | `--chrome` |
-| `debug` | `--debug` |
-| `worktree` | `--worktree` |
-| `verbose` | `--verbose` |
-| `output_format` | `--output-format <value>` |
-| `session_id` | `--session-id <session_id>` |
-| `resume` + `session_id` | `--resume <session_id>` |
-| `fork_session_id` | `--resume <source> --fork-session --session-id <new>` |
-| `model` | `--model <model>` |
-| `effort` | `--effort <effort>` |
-| `agents_json` | `--agents '<json>'` |
-| `additional_dirs` / `add_dirs` | repeated `--add-dir <path>` |
-| `print_mode` | `-p` |
+| Option                                | CLI effect                                            |
+| ------------------------------------- | ----------------------------------------------------- |
+| `permission_mode='bypassPermissions'` | `--dangerously-skip-permissions`                      |
+| `chrome`                              | `--chrome`                                            |
+| `debug`                               | `--debug`                                             |
+| `worktree`                            | `--worktree`                                          |
+| `verbose`                             | `--verbose`                                           |
+| `output_format`                       | `--output-format <value>`                             |
+| `session_id`                          | `--session-id <session_id>`                           |
+| `resume` + `session_id`               | `--resume <session_id>`                               |
+| `fork_session_id`                     | `--resume <source> --fork-session --session-id <new>` |
+| `model`                               | `--model <model>`                                     |
+| `effort`                              | `--effort <effort>`                                   |
+| `agents_json`                         | `--agents '<json>'`                                   |
+| `additional_dirs` / `add_dirs`        | repeated `--add-dir <path>`                           |
+| `print_mode`                          | `-p`                                                  |
 
 For Codex, `CodexCliOptions` builds `codex exec` arguments such as `--json`, `--ephemeral`, `-C <workdir>`, `-m <model>`, and `--dangerously-bypass-approvals-and-sandbox`.
 
@@ -437,7 +441,7 @@ await process.embeddedAssets.detach('skill-<id>');
 const refs = process.embeddedAssets.list();
 ```
 
----
+***
 
 ## Backend API
 
@@ -456,26 +460,26 @@ POST /api/v1/graph/compute_node/<id>/upsertSessionProcess
 
 ### AgenticProcess Actions
 
-| Action | Method | Description |
-|--------|--------|-------------|
-| `open` | `POST` | Start or reopen visible PTY mode through `AgenticProcess.start()`. |
-| `exit` | `POST` | Stop worker and PTY while preserving the linked `Shell` entity. |
-| `restart` | `POST` | `exit()` then `start()`. |
-| `close` | `POST` | Permanent teardown: close/delete linked `Shell`, clear shell links, stop process. |
-| `fork` | `POST` | Create a sibling process that forks from this process's `session_id`. |
-| `execute` | `POST` | Execute an instruction through `prompt()`; routes by `visible`. |
-| `prompt` | `POST` | Print-mode streaming HTTP prompt; rejects visible PTY processes. |
-| `cancel-prompt` | `POST` | Cancel an in-flight print-mode worker. |
-| `execute-plan` | `POST` | Inject a plan execution prompt into an active PTY session. |
-| `update-plan` | `POST` | Inject a plan-update prompt into an active PTY session. |
-| `load-embedded-agent` | `POST` | Merge an agent spec into `cli_config.agents_json`. |
-| `attach-embedded-asset` | `POST` | Materialize an agent/skill under the process assets dir. |
-| `detach-embedded-asset` | `POST` | Remove a materialized embedded asset. |
-| `list-embedded-assets` | `GET` | Return current embedded asset TypeIds. |
-| `get-history` | `GET` | Load transcript history as `FlowData`. |
-| `status` | `GET/POST` | Return stored `status`, computed `worker_status`, and `ready_for_input`. |
-| `add-dir` | `POST` | Append a directory to `additional_dirs`. |
-| `input-dir` | `GET` | Return/create the process input directory. |
+| Action                  | Method     | Description                                                                       |
+| ----------------------- | ---------- | --------------------------------------------------------------------------------- |
+| `open`                  | `POST`     | Start or reopen visible PTY mode through `AgenticProcess.start()`.                |
+| `exit`                  | `POST`     | Stop worker and PTY while preserving the linked `Shell` entity.                   |
+| `restart`               | `POST`     | `exit()` then `start()`.                                                          |
+| `close`                 | `POST`     | Permanent teardown: close/delete linked `Shell`, clear shell links, stop process. |
+| `fork`                  | `POST`     | Create a sibling process that forks from this process's `session_id`.             |
+| `execute`               | `POST`     | Execute an instruction through `prompt()`; routes by `visible`.                   |
+| `prompt`                | `POST`     | Print-mode streaming HTTP prompt; rejects visible PTY processes.                  |
+| `cancel-prompt`         | `POST`     | Cancel an in-flight print-mode worker.                                            |
+| `execute-plan`          | `POST`     | Inject a plan execution prompt into an active PTY session.                        |
+| `update-plan`           | `POST`     | Inject a plan-update prompt into an active PTY session.                           |
+| `load-embedded-agent`   | `POST`     | Merge an agent spec into `cli_config.agents_json`.                                |
+| `attach-embedded-asset` | `POST`     | Materialize an agent/skill under the process assets dir.                          |
+| `detach-embedded-asset` | `POST`     | Remove a materialized embedded asset.                                             |
+| `list-embedded-assets`  | `GET`      | Return current embedded asset TypeIds.                                            |
+| `get-history`           | `GET`      | Load transcript history as `FlowData`.                                            |
+| `status`                | `GET/POST` | Return stored `status`, computed `worker_status`, and `ready_for_input`.          |
+| `add-dir`               | `POST`     | Append a directory to `additional_dirs`.                                          |
+| `input-dir`             | `GET`      | Return/create the process input directory.                                        |
 
 ### Shell Actions Used By PTY Mode
 
@@ -483,16 +487,16 @@ POST /api/v1/graph/compute_node/<id>/upsertSessionProcess
 
 Relevant `Shell` actions:
 
-| Action | Description |
-|--------|-------------|
-| `open` | Start a generic shell PTY. |
-| `close` | Kill PTY, delete disk record, delete shell entity. |
-| `run` | Run a subprocess command and return stdout/stderr/exit code. |
-| `set-env` | Persist and inject shell environment variables. |
-| `update-display` | Update shell display metadata. |
-| `fetch-pty-sequence` | Fetch replay-buffer data by sequence. |
+| Action               | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `open`               | Start a generic shell PTY.                                   |
+| `close`              | Kill PTY, delete disk record, delete shell entity.           |
+| `run`                | Run a subprocess command and return stdout/stderr/exit code. |
+| `set-env`            | Persist and inject shell environment variables.              |
+| `update-display`     | Update shell display metadata.                               |
+| `fetch-pty-sequence` | Fetch replay-buffer data by sequence.                        |
 
----
+***
 
 ## TypeScript API
 
@@ -515,136 +519,137 @@ The current files are under `ts_sdk/src/process/`, not `ts_sdk/src/agentic_proce
 
 `IAgenticProcess` includes:
 
-| Property | Description |
-|----------|-------------|
-| `status` | Stored `ProcessStatus`. |
-| `worker_status` / `workerStatus` | Computed `WorkerStatus`. |
-| `ready_for_input` | Server-computed readiness flag. |
-| `session_id` | Persistent worker session ID. |
-| `shell_id` | Linked `Shell` for PTY mode. |
-| `visible` | Mode selector. |
-| `cli_config` | Serialized worker CLI options. |
-| `context_data` | Persisted extra context. |
-| `workdir` | Worker working directory. |
-| `shell_mode` | Direct PTY spawn vs legacy shell intermediary. |
-| `additional_dirs` | Extra `--add-dir` directories. |
-| `embedded_asset_refs` | Embedded agent/skill refs. |
-| `project_id`, `project_encoded_name` | Project linkage. |
-| `exe_folder`, `input_folder`, `output_folder`, `assets_folder` | Execution folder refs. |
+| Property                                                       | Description                                    |
+| -------------------------------------------------------------- | ---------------------------------------------- |
+| `status`                                                       | Stored `ProcessStatus`.                        |
+| `worker_status` / `workerStatus`                               | Computed `WorkerStatus`.                       |
+| `ready_for_input`                                              | Server-computed readiness flag.                |
+| `session_id`                                                   | Persistent worker session ID.                  |
+| `shell_id`                                                     | Linked `Shell` for PTY mode.                   |
+| `visible`                                                      | Mode selector.                                 |
+| `cli_config`                                                   | Serialized worker CLI options.                 |
+| `context_data`                                                 | Persisted extra context.                       |
+| `workdir`                                                      | Worker working directory.                      |
+| `shell_mode`                                                   | Direct PTY spawn vs legacy shell intermediary. |
+| `additional_dirs`                                              | Extra `--add-dir` directories.                 |
+| `embedded_asset_refs`                                          | Embedded agent/skill refs.                     |
+| `project_id`, `project_encoded_name`                           | Project linkage.                               |
+| `exe_folder`, `input_folder`, `output_folder`, `assets_folder` | Execution folder refs.                         |
 
 Convenience getters:
 
-| Getter | Description |
-|--------|-------------|
-| `cliOptions` | Deserializes `cli_config` to `ClaudeCliOptions` and injects `session_id`, `workdir`, and `additional_dirs`. |
-| `shellEntity` | Cached linked `Shell`, if available. |
-| `compute_node_id` / `compute_node_uname` | Delegated from the linked shell. |
-| `ptyConnection` | Delegated from the linked shell. |
-| `completed` / `error` / `historyLoaded` | Client-side stream state. |
-| `workDirVfs` | `workdir` converted to `VFSPath`. |
+| Getter                                   | Description                                                                                                 |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `cliOptions`                             | Deserializes `cli_config` to `ClaudeCliOptions` and injects `session_id`, `workdir`, and `additional_dirs`. |
+| `shellEntity`                            | Cached linked `Shell`, if available.                                                                        |
+| `compute_node_id` / `compute_node_uname` | Delegated from the linked shell.                                                                            |
+| `ptyConnection`                          | Delegated from the linked shell.                                                                            |
+| `completed` / `error` / `historyLoaded`  | Client-side stream state.                                                                                   |
+| `workDirVfs`                             | `workdir` converted to `VFSPath`.                                                                           |
 
 ### Static Methods
 
-| Method | Description |
-|--------|-------------|
-| `AgenticProcess.execute(command, options?)` | Simple one-shot helper. Creates a process on the current compute node and calls `executeInstruction()`. |
-| `AgenticProcess.spawn(options, workerOptions?)` | Create and optionally activate a process. Without `headless: true` it opens a PTY; pass `visible: true` for user-visible terminal tabs. |
-| `AgenticProcess.getByIdWithHistory(id)` | Fetch process and call `loadHistory()`. |
-| `AgenticProcess.open(sessionId)` | Upsert a process for a Claude session ID. |
-| `AgenticProcess.fromWorkerSessionId('claude', sessionId)` | Alias for opening by session ID. The public name is legacy; the entity field is `session_id`. |
-| `AgenticProcess.openRecordInTerminal(record)` | Ensure an existing record/session has a live PTY. |
-| `AgenticProcess.fromClaudeSession(sessionId, cwd?)` | Resolve/create a process from a Claude session record. |
+| Method                                                    | Description                                                                                                                             |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `AgenticProcess.execute(command, options?)`               | Simple one-shot helper. Creates a process on the current compute node and calls `executeInstruction()`.                                 |
+| `AgenticProcess.spawn(options, workerOptions?)`           | Create and optionally activate a process. Without `headless: true` it opens a PTY; pass `visible: true` for user-visible terminal tabs. |
+| `AgenticProcess.getByIdWithHistory(id)`                   | Fetch process and call `loadHistory()`.                                                                                                 |
+| `AgenticProcess.open(sessionId)`                          | Upsert a process for a Claude session ID.                                                                                               |
+| `AgenticProcess.fromWorkerSessionId('claude', sessionId)` | Alias for opening by session ID. The public name is legacy; the entity field is `session_id`.                                           |
+| `AgenticProcess.openRecordInTerminal(record)`             | Ensure an existing record/session has a live PTY.                                                                                       |
+| `AgenticProcess.fromClaudeSession(sessionId, cwd?)`       | Resolve/create a process from a Claude session record.                                                                                  |
 
 ### Instance Methods
 
-| Method | Mode | Description |
-|--------|------|-------------|
-| `start(options?)` | PTY | Calls backend `open`; creates/reuses a Shell PTY and attaches the frontend. |
-| `sendInput(text)` | PTY | Sends text through the active PTY connection. |
-| `inject(message)` | PTY | Frontend compatibility helper for queue-style injection; current backend PTY injection is primarily used internally by plan actions. |
-| `executePlan(filePath, options?)` | PTY | Inject plan execution prompt. |
-| `updatePlan(filePath)` | PTY | Inject plan update prompt. |
-| `exit()` / `stop()` | PTY | Stop worker and PTY but keep shell entity. |
-| `restart()` | PTY | Stop then start, preserving session history. |
-| `close()` | PTY | Permanent teardown of the linked shell. |
-| `fork(visible?)` | PTY | Create and open a forked sibling process. |
-| `prompt(text, abortController?)` | CLI | Streaming print-mode prompt over HTTP. |
-| `cancelPrompt()` | CLI | Cancel the active print-mode subprocess. |
-| `executeInstruction(instruction, options?)` | Both | Calls backend `execute`; backend routes by `visible`. |
-| `wait()` | Both | Wait for terminal `workerStatus`/failed lifecycle. |
-| `output()` | Both | Async iterator over collected and live `FlowData`. |
-| `getOutputs()` | Both | Synchronous access to collected `FlowData`. |
-| `loadHistory(options?)` | Both | Load transcript history into the `FlowData` stream. |
-| `appendUserMessage(content)` | Both | Optimistically append a user message to the stream. |
+| Method                                      | Mode | Description                                                                                                                          |
+| ------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `start(options?)`                           | PTY  | Calls backend `open`; creates/reuses a Shell PTY and attaches the frontend.                                                          |
+| `sendInput(text)`                           | PTY  | Sends text through the active PTY connection.                                                                                        |
+| `inject(message)`                           | PTY  | Frontend compatibility helper for queue-style injection; current backend PTY injection is primarily used internally by plan actions. |
+| `executePlan(filePath, options?)`           | PTY  | Inject plan execution prompt.                                                                                                        |
+| `updatePlan(filePath)`                      | PTY  | Inject plan update prompt.                                                                                                           |
+| `exit()` / `stop()`                         | PTY  | Stop worker and PTY but keep shell entity.                                                                                           |
+| `restart()`                                 | PTY  | Stop then start, preserving session history.                                                                                         |
+| `close()`                                   | PTY  | Permanent teardown of the linked shell.                                                                                              |
+| `fork(visible?)`                            | PTY  | Create and open a forked sibling process.                                                                                            |
+| `prompt(text, abortController?)`            | CLI  | Streaming print-mode prompt over HTTP.                                                                                               |
+| `cancelPrompt()`                            | CLI  | Cancel the active print-mode subprocess.                                                                                             |
+| `executeInstruction(instruction, options?)` | Both | Calls backend `execute`; backend routes by `visible`.                                                                                |
+| `wait()`                                    | Both | Wait for terminal `workerStatus`/failed lifecycle.                                                                                   |
+| `output()`                                  | Both | Async iterator over collected and live `FlowData`.                                                                                   |
+| `getOutputs()`                              | Both | Synchronous access to collected `FlowData`.                                                                                          |
+| `loadHistory(options?)`                     | Both | Load transcript history into the `FlowData` stream.                                                                                  |
+| `appendUserMessage(content)`                | Both | Optimistically append a user message to the stream.                                                                                  |
 
 ### Events
 
 `AgenticProcess` extends `APIEntity` and emits:
 
-| Event | Description |
-|-------|-------------|
-| `flow_data` | New `FlowData` arrived. |
-| `complete` | Client-side stream marked complete. |
-| `error` | Client-side stream marked failed. |
+| Event          | Description                           |
+| -------------- | ------------------------------------- |
+| `flow_data`    | New `FlowData` arrived.               |
+| `complete`     | Client-side stream marked complete.   |
+| `error`        | Client-side stream marked failed.     |
 | `state_change` | Delta for `status` or `workerStatus`. |
-| `restarted` | Emitted after frontend `restart()`. |
+| `restarted`    | Emitted after frontend `restart()`.   |
 
----
+***
 
 ## Stale Names
 
 The following names appear in older docs or compatibility shims but are not the current model:
 
-| Stale concept | Current term / behavior |
-|---------------|-------------------------|
-| `AgenticProcessor` parent | Use `ComputeNode.createProcess` / direct `AgenticProcess`; the current entity is standalone. |
-| `ts_sdk/src/agentic_processor/*` | Current SDK paths are `ts_sdk/src/process/*`. |
-| `flow_sdk/builtin/agentic_processor.py` | Current backend entity file is `flow_sdk/builtin/agentic_process/agentic_process.py`. |
-| `worker_session_id` | Use `session_id` on `AgenticProcess`. Some old compatibility code may accept or expose the old name, but it is not canonical. |
-| process-level `pty_pid` | PTY state is on `Shell.pty_pid`; process links via `shell_id`. |
-| `startPty()`, `resumePty()`, `killPty()` | Use `start()`/`open`, `restart()` or `start()` after stale shell, `exit()`/`close()`. |
-| `state.status` | Use stored `status` plus computed `worker_status`; there is no persisted `ProcessorState` status source on current `AgenticProcess`. |
-| AMD processor/debug run loop | Not part of the current `AgenticProcess` backend file. Current execution is worker CLI prompt/PTY plus FlowData history. |
+| Stale concept                            | Current term / behavior                                                                                                              |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `AgenticProcessor` parent                | Use `ComputeNode.createProcess` / direct `AgenticProcess`; the current entity is standalone.                                         |
+| `ts_sdk/src/agentic_processor/*`         | Current SDK paths are `ts_sdk/src/process/*`.                                                                                        |
+| `flow_sdk/builtin/agentic_processor.py`  | Current backend entity file is `flow_sdk/builtin/agentic_process/agentic_process.py`.                                                |
+| `worker_session_id`                      | Use `session_id` on `AgenticProcess`. Some old compatibility code may accept or expose the old name, but it is not canonical.        |
+| process-level `pty_pid`                  | PTY state is on `Shell.pty_pid`; process links via `shell_id`.                                                                       |
+| `startPty()`, `resumePty()`, `killPty()` | Use `start()`/`open`, `restart()` or `start()` after stale shell, `exit()`/`close()`.                                                |
+| `state.status`                           | Use stored `status` plus computed `worker_status`; there is no persisted `ProcessorState` status source on current `AgenticProcess`. |
+| AMD processor/debug run loop             | Not part of the current `AgenticProcess` backend file. Current execution is worker CLI prompt/PTY plus FlowData history.             |
 
----
+***
 
 ## Key Files Reference
 
 ### Backend Python
 
-| File | Role |
-|------|------|
-| `flow_sdk/builtin/agentic_process/agentic_process.py` | Main `AgenticProcess` entity, lifecycle, prompt/open/close actions, serialization. |
-| `flow_sdk/builtin/agentic_process/status_predicates.py` | `WorkerMode`, `is_ready_for_input`, process/worker predicate exports. |
-| `flow_sdk/builtin/agentic_process/cli_drivers/cli_worker_base_driver.py` | `AgenticContext`, `AgenticWorker`, `WorkerCLIOptions`, `WorkerDriver`, `get_driver()`. |
-| `flow_sdk/builtin/agentic_process/cli_drivers/claude/driver.py` | Claude driver: CLI options, print turns, transcript path/status/history, prompt composition. |
-| `flow_sdk/builtin/agentic_process/cli_drivers/claude/cli.py` | Claude CLI option builder and direct PTY spawn args. |
-| `flow_sdk/builtin/agentic_process/cli_drivers/claude/stream_worker.py` | `claude -p --output-format stream-json` print-mode worker. |
-| `flow_sdk/builtin/agentic_process/cli_drivers/codex/driver.py` | Codex driver: print turns, process-local transcript, history/status. |
-| `flow_sdk/builtin/agentic_process/cli_drivers/codex/cli.py` | Codex CLI option builder. |
-| `flow_sdk/builtin/agentic_process/cli_drivers/codex/stream_worker.py` | `codex exec --json --ephemeral` print-mode worker. |
-| `flow_sdk/builtin/shell.py` | Shell entity that owns PTY sessions and worker OS process metadata. |
-| `flow_sdk/builtin/faas/scan_actions.py` | `ComputeNode.createProcess` and `upsertSessionProcess` implementations. |
-| `flow_sdk/fs_records/agent_status.py` | `WorkerStatus` and Claude transcript tail-status derivation. |
-| `flow_sdk/fs_records/agentic_process_lifecycle.py` | `ProcessStatus` lifecycle enum and helpers. |
-| `flow_sdk/fs_records/agentic_process_record.py` | Filesystem record and execution folder layout. |
+| File                                                                     | Role                                                                                         |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `flow_sdk/builtin/agentic_process/agentic_process.py`                    | Main `AgenticProcess` entity, lifecycle, prompt/open/close actions, serialization.           |
+| `flow_sdk/builtin/agentic_process/status_predicates.py`                  | `WorkerMode`, `is_ready_for_input`, process/worker predicate exports.                        |
+| `flow_sdk/builtin/agentic_process/cli_drivers/cli_worker_base_driver.py` | `AgenticContext`, `AgenticWorker`, `WorkerCLIOptions`, `WorkerDriver`, `get_driver()`.       |
+| `flow_sdk/builtin/agentic_process/cli_drivers/claude/driver.py`          | Claude driver: CLI options, print turns, transcript path/status/history, prompt composition. |
+| `flow_sdk/builtin/agentic_process/cli_drivers/claude/cli.py`             | Claude CLI option builder and direct PTY spawn args.                                         |
+| `flow_sdk/builtin/agentic_process/cli_drivers/claude/stream_worker.py`   | `claude -p --output-format stream-json` print-mode worker.                                   |
+| `flow_sdk/builtin/agentic_process/cli_drivers/codex/driver.py`           | Codex driver: print turns, process-local transcript, history/status.                         |
+| `flow_sdk/builtin/agentic_process/cli_drivers/codex/cli.py`              | Codex CLI option builder.                                                                    |
+| `flow_sdk/builtin/agentic_process/cli_drivers/codex/stream_worker.py`    | `codex exec --json --ephemeral` print-mode worker.                                           |
+| `flow_sdk/builtin/shell.py`                                              | Shell entity that owns PTY sessions and worker OS process metadata.                          |
+| `flow_sdk/builtin/faas/scan_actions.py`                                  | `ComputeNode.createProcess` and `upsertSessionProcess` implementations.                      |
+| `flow_sdk/fs_records/agent_status.py`                                    | `WorkerStatus` and Claude transcript tail-status derivation.                                 |
+| `flow_sdk/fs_records/agentic_process_lifecycle.py`                       | `ProcessStatus` lifecycle enum and helpers.                                                  |
+| `flow_sdk/fs_records/agentic_process_record.py`                          | Filesystem record and execution folder layout.                                               |
 
 ### TypeScript SDK
 
-| File | Role |
-|------|------|
-| `ts_sdk/src/process/agentic-process.ts` | `AgenticProcess` class, spawn/start/prompt/execute/history methods. |
-| `ts_sdk/src/process/agentic-context.ts` | `AgenticContext`, spawn options, context serialization. |
-| `ts_sdk/src/process/agentic-types.ts` | `ProcessStatus`, `WorkerStatus`, `WorkerMode`, display/readiness helpers. |
-| `ts_sdk/src/process/index.ts` | Process module exports. |
-| `ts_sdk/src/entities/compute-node/compute-node.ts` | Frontend `createProcess()` and `upsertSessionProcess()` calls. |
-| `ts_sdk/src/entities/shell.ts` | Shell entity consumed by PTY mode. |
-| `ts_sdk/src/services/shell/ptyConnection.ts` | Frontend PTY attachment/input stream. |
-| `ts_sdk/src/cli_workers/claude-cli.ts` | TypeScript Claude CLI option builder. |
+| File                                               | Role                                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------- |
+| `ts_sdk/src/process/agentic-process.ts`            | `AgenticProcess` class, spawn/start/prompt/execute/history methods.       |
+| `ts_sdk/src/process/agentic-context.ts`            | `AgenticContext`, spawn options, context serialization.                   |
+| `ts_sdk/src/process/agentic-types.ts`              | `ProcessStatus`, `WorkerStatus`, `WorkerMode`, display/readiness helpers. |
+| `ts_sdk/src/process/index.ts`                      | Process module exports.                                                   |
+| `ts_sdk/src/entities/compute-node/compute-node.ts` | Frontend `createProcess()` and `upsertSessionProcess()` calls.            |
+| `ts_sdk/src/entities/shell.ts`                     | Shell entity consumed by PTY mode.                                        |
+| `ts_sdk/src/services/shell/ptyConnection.ts`       | Frontend PTY attachment/input stream.                                     |
+| `ts_sdk/src/cli_workers/claude-cli.ts`             | TypeScript Claude CLI option builder.                                     |
 
 ### Frontend/UI References
 
-| Path | Role |
-|------|------|
+| Path                                               | Role                                         |
+| -------------------------------------------------- | -------------------------------------------- |
 | `ui/src/components/terminal/interactive-terminal/` | Interactive terminal UI and process toolbar. |
-| `ui/src/components/terminal/TabbedTerminal.tsx` | Multi-tab terminal orchestration. |
+| `ui/src/components/terminal/TabbedTerminal.tsx`    | Multi-tab terminal orchestration.            |
+

--- a/flow_sdk/builtin/agentic_process/agentic_process.py
+++ b/flow_sdk/builtin/agentic_process/agentic_process.py
@@ -95,6 +95,7 @@ class AssetDescriptor:
     typeid: str               # serialized TypeId, e.g. "skill-<uuid>"
     source: AssetSource
     posix_path: str | None    # canonical POSIX path; None for INLINE
+    source_dir: str | None = None  # matched source dir (path-discovered only); None for EMBEDDED/INLINE
 
 
 # Types treated as executable agent inputs by the asset-management UI.
@@ -109,12 +110,24 @@ EXECUTABLE_ASSET_TYPES: list[str] = ["skill", "agent"]
 _PROMPT_LOCKS: dict[str, asyncio.Lock] = {}
 _PROMPT_WORKERS: dict[str, Any] = {}
 
+# Per-process serialization for the ``open``/``start`` lifecycle so two
+# concurrent refresh-driven calls can't both run recovery on the same process.
+_OPEN_LOCKS: dict[str, asyncio.Lock] = {}
+
 
 def _get_prompt_lock(process_id: str) -> asyncio.Lock:
     lock = _PROMPT_LOCKS.get(process_id)
     if lock is None:
         lock = asyncio.Lock()
         _PROMPT_LOCKS[process_id] = lock
+    return lock
+
+
+def _get_open_lock(process_id: str) -> asyncio.Lock:
+    lock = _OPEN_LOCKS.get(process_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _OPEN_LOCKS[process_id] = lock
     return lock
 
 
@@ -144,6 +157,33 @@ def _write_plan_frontmatter(file_path: str, fields: dict) -> None:
         )
         new_content = f"---\n{lines}\n---\n{content}"
     p.write_text(new_content, encoding="utf-8")
+
+
+async def _index_additional_dir(path: str) -> None:
+    """Run a one-shot indexer scan over ``path`` so its skills/agents become
+    discoverable via ``Entity.assets_by_path``.
+
+    Best-effort and silent: if the path doesn't exist or the indexer raises,
+    we log and continue — adding the dir to ``additional_dirs`` already
+    succeeded.
+    """
+    try:
+        from pathlib import Path as _Path
+        from flow_sdk.fs_store.fs_ref import FSRef
+        from flow_sdk.fs_store.record_types import RecordType
+        from flow_sdk.fs_store.indexer import IndexerOptions, get_shared_indexer
+
+        p = _Path(path)
+        if not p.is_dir():
+            return
+        new_root = FSRef(p, record_type=RecordType.CWD_ROOT, scope="user")
+        # include_temp=True so /tmp / /var/folders paths aren't filtered out —
+        # the user explicitly added this dir, so honor it regardless of location.
+        await get_shared_indexer().index(
+            IndexerOptions(roots=(new_root,), verbose=False, include_temp=True)
+        )
+    except Exception:
+        logger.exception("add_dir: indexing failed for %s", path)
 
 
 async def _index_session_on_close(session_id: str, pty_title: str | None = None) -> None:
@@ -489,11 +529,30 @@ class AgenticProcess(Entity):
           the dead PTY, cleans up, and spawns Claude with --resume.
         - Idempotent call on live process: Shell.start() detects alive PTY and returns
           without re-spawning.
+
+        Body runs under a per-process ``_OPEN_LOCKS`` lock so two concurrent
+        refresh-driven open calls (e.g. two browser tabs) can't both run
+        recovery on the same process and double-spawn Claude.
         """
         # Suppress the restart-required auto-flag while start() mutates fields
         # (status, session_id are tracked, but those mutations are not "drift").
         # Cleared on success after we capture the new snapshot.
         self._set_start_lifecycle(True)
+        try:
+            async with _get_open_lock(self.id):
+                return await self._perform_open(instruction, visible)
+        finally:
+            self._set_start_lifecycle(False)
+
+    async def _perform_open(
+        self,
+        instruction: str | None,
+        visible: bool | None,
+    ) -> ApiSuccessResponse | ApiFailResponse:
+        """Body of ``start``/``open`` — runs while the per-process open lock
+        is held. All lifecycle decisions (reattach vs recover vs fresh) live
+        here; the caller is responsible for the lock and the start-lifecycle
+        flag."""
         try:
             _bench_t0 = time.perf_counter()
             _bench_id = self.id[:8]
@@ -515,14 +574,31 @@ class AgenticProcess(Entity):
                 ProcessStatus.STARTING.value,
                 ProcessStatus.RUNNING.value,
             ) and self.shell_id:
-                if shell is not None and await shell.has_attachable_pty():
+                # Reattach gate: both the PTY session AND the worker PID must be
+                # alive. ``has_attachable_pty()`` only proves the pseudo-terminal
+                # is registered on the compute node — it accepts a PTY whose
+                # Claude child has already exited. Pairing it with
+                # ``worker_alive()`` (psutil-based PID + cmdline match) is what
+                # prevents the "empty terminal after refresh" symptom.
+                if (
+                    shell is not None
+                    and await shell.has_attachable_pty()
+                    and await shell.worker_alive()
+                ):
                     if self.status != ProcessStatus.RUNNING.value:
                         self.status = ProcessStatus.RUNNING.value
                         await self.save()
                     return ApiSuccessResponse(data=self._build_open_payload(shell, is_resume=False))
-                if self.status == ProcessStatus.STARTING.value:
-                    await self._drop_stale_shell(shell, reason="starting process is missing an attachable PTY")
-                    shell = None
+                # Gate failed (PTY dead, worker dead, or both). Drop the stale
+                # shell so the relaunch path below sees a clean slate — without
+                # this, ``_get_or_create_shell`` would hand back the same
+                # half-dead shell entity and the new ``claude --resume`` would
+                # collide with the old worker's lingering JSONL session lock.
+                await self._drop_stale_shell(
+                    shell,
+                    reason=f"{self.status} process is missing a fully-alive PTY+worker",
+                )
+                shell = None
 
             await self.get_project()
             _bench("after get_project")
@@ -628,8 +704,6 @@ class AgenticProcess(Entity):
             self.status = ProcessStatus.FAILED.value
             await self.save()
             return ApiFailResponse(message=str(e))
-        finally:
-            self._set_start_lifecycle(False)
 
     @action.post(action_name="exit")
     async def exit(self) -> ApiSuccessResponse | ApiFailResponse:
@@ -1559,16 +1633,18 @@ class AgenticProcess(Entity):
                 if not ar_raw:
                     continue
                 ar = canonical_posix_path(ar_raw)
-                src = next(
-                    (s for path, s in ranked if ar == path or ar.startswith(path + "/")),
+                match = next(
+                    ((path, s) for path, s in ranked if ar == path or ar.startswith(path + "/")),
                     None,
                 )
-                if src is None:
+                if match is None:
                     continue
+                src_dir, src = match
                 descriptors.append(AssetDescriptor(
                     typeid=f"{ent.type or ent.get_type()}-{ent.id}",
                     source=src,
                     posix_path=ar,
+                    source_dir=src_dir,
                 ))
 
         return descriptors
@@ -1770,7 +1846,12 @@ class AgenticProcess(Entity):
         """HTTP wrapper around ``get_asset_descriptors``."""
         items = await self.get_asset_descriptors()
         return ApiSuccessResponse(data={"assets": [
-            {"typeid": d.typeid, "source": d.source.value, "posix_path": d.posix_path}
+            {
+                "typeid": d.typeid,
+                "source": d.source.value,
+                "posix_path": d.posix_path,
+                "source_dir": d.source_dir,
+            }
             for d in items
         ]})
 
@@ -1942,10 +2023,25 @@ class AgenticProcess(Entity):
 
     @action.post(action_name="add-dir")
     async def add_dir(self, path: str) -> "ApiResponse":
-        """Append a directory to additional_dirs (passed to Claude via --add-dir)."""
+        """Append a directory to additional_dirs (passed to Claude via --add-dir).
+
+        Also kicks off a one-shot indexer scan over the new path so any skills
+        / agents living under it become discoverable via ``get_asset_descriptors``
+        without requiring a manual ``flow record index``.
+        """
         from flow_sdk.responses.response import ApiSuccessResponse
         if path not in (self.additional_dirs or []):
             self.additional_dirs = list(self.additional_dirs or []) + [path]
+            await self.save()
+            await _index_additional_dir(path)
+        return ApiSuccessResponse()
+
+    @action.post(action_name="remove-dir")
+    async def remove_dir(self, path: str) -> "ApiResponse":
+        """Remove a directory from additional_dirs. No-op if not present."""
+        from flow_sdk.responses.response import ApiSuccessResponse
+        if path in (self.additional_dirs or []):
+            self.additional_dirs = [d for d in (self.additional_dirs or []) if d != path]
             await self.save()
         return ApiSuccessResponse()
 

--- a/flow_sdk/builtin/shell.py
+++ b/flow_sdk/builtin/shell.py
@@ -335,27 +335,46 @@ class Shell(Entity):
         await self.start()
 
     async def terminate_worker(self) -> None:
-        """Gracefully kill the Claude worker: SIGTERM, wait 3s, SIGKILL if needed.
+        """Gracefully kill the Claude worker and wait for full reap.
+
+        SIGTERM the worker and its descendants, wait up to 3s for the kernel
+        to reap them, then SIGKILL any survivors and wait again. Returns only
+        once every victim is fully reaped — once that holds, any flock-held
+        resources (e.g. Claude's JSONL session lock) are released, so a
+        subsequent ``claude --resume`` won't collide with the dead worker's
+        leftover lock file.
 
         Shell entity and PTY are left alive (status unchanged).
         Uses self.worker_pid set by _launch_worker_process().
         """
-        import signal
-
         pid = self.worker_pid
         if not pid:
             return
         try:
-            os.kill(pid, signal.SIGTERM)
-            deadline = asyncio.get_event_loop().time() + 3.0
-            while asyncio.get_event_loop().time() < deadline:
-                if not psutil.pid_exists(pid):
-                    return
-                await asyncio.sleep(0.1)
-            if psutil.pid_exists(pid):
-                os.kill(pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass  # already gone
+            proc = psutil.Process(pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return
+        try:
+            children = proc.children(recursive=True)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            children = []
+        victims = [proc, *children]
+
+        for p in victims:
+            try:
+                p.terminate()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+        # wait_procs is blocking; offload so we don't stall the event loop.
+        gone, alive = await asyncio.to_thread(psutil.wait_procs, victims, 3.0)
+        if alive:
+            for p in alive:
+                try:
+                    p.kill()
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+            await asyncio.to_thread(psutil.wait_procs, alive, 2.0)
 
     # ── I/O ───────────────────────────────────────────────────────────────────
 

--- a/tests/unit/test_agentic_process_get_assets.py
+++ b/tests/unit/test_agentic_process_get_assets.py
@@ -413,6 +413,67 @@ def test_is_readonly_source_partition():
 
 
 @pytest.mark.asyncio
+async def test_source_dir_populated_for_path_discovered(tree):
+    """Path-discovered descriptors carry source_dir = the matched root dir.
+
+    EMBEDDED + INLINE descriptors leave source_dir as None — they aren't
+    attributed to any source dir.
+    """
+    from flow_sdk.api.api_types.type_id import TypeId
+    proc = _make_proc(
+        workdir=str(tree["workdir_outside"]),
+        additional_dirs=[str(tree["extra_dir"])],
+        embedded_asset_refs=[tree["ents"]["u_skill_user"].typeid],
+        cli_config={"agents_json": {"inline_x": {"description": "y"}}},
+    )
+    descs = await proc.get_asset_descriptors()
+
+    user_canon = canonical_posix_path(tree["user_home"])
+    workdir_canon = canonical_posix_path(tree["workdir_outside"])
+    extra_canon = canonical_posix_path(tree["extra_dir"])
+
+    by_source = {s: _by_source(descs, s) for s in AssetSource}
+
+    # Each path-discovered descriptor's source_dir matches its source enum.
+    for d in by_source[AssetSource.USER_DIR]:
+        assert d.source_dir == user_canon, d
+    for d in by_source[AssetSource.WORKDIR]:
+        assert d.source_dir == workdir_canon, d
+    for d in by_source[AssetSource.ADDITIONAL_DIR]:
+        assert d.source_dir == extra_canon, d
+
+    # EMBEDDED and INLINE never carry a source_dir.
+    for d in by_source[AssetSource.EMBEDDED] + by_source[AssetSource.INLINE]:
+        assert d.source_dir is None, d
+
+
+@pytest.mark.asyncio
+async def test_remove_dir_action(tree):
+    """`remove_dir` removes a path from additional_dirs; no-op on unknowns."""
+    extra = str(tree["extra_dir"])
+    other = str(tree["workdir_outside"])
+    proc = _make_proc(additional_dirs=[extra, other])
+
+    # Stub out save() so the test doesn't need a writable backing store.
+    saved: list[None] = []
+    async def _fake_save(self):
+        saved.append(None)
+        return self
+    import types
+    proc.save = types.MethodType(_fake_save, proc)
+
+    await proc.remove_dir(extra)
+    assert proc.additional_dirs == [other]
+    assert saved, "save() should run when the dir was actually removed"
+
+    # Idempotent on unknown path: no save, no mutation.
+    saved.clear()
+    await proc.remove_dir("/nonexistent/path")
+    assert proc.additional_dirs == [other]
+    assert not saved, "save() must not run when the dir wasn't present"
+
+
+@pytest.mark.asyncio
 async def test_get_asset_descriptors_read_only_partition(tree, monkeypatch):
     """Every descriptor returned by get_asset_descriptors() agrees with
     is_readonly_source — no surprise/dynamic mismatches between actual

--- a/ts_sdk/src/process/agentic-process.ts
+++ b/ts_sdk/src/process/agentic-process.ts
@@ -603,8 +603,20 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
 
   /** Append a directory to additional_dirs (passed to Claude via --add-dir). */
   async addDir(path: string): Promise<void> {
-    await this.callAction('add-dir', { path });
-    this.additional_dirs = [...(this.additional_dirs ?? []), path];
+    const actionInfo = new ActionInfo('add-dir', AgenticProcess.type, this.id, 'POST');
+    actionInfo.bodyParameters = { path };
+    await dataManager.callAction(actionInfo);
+    if (!(this.additional_dirs ?? []).includes(path)) {
+      this.additional_dirs = [...(this.additional_dirs ?? []), path];
+    }
+  }
+
+  /** Remove a directory from additional_dirs. No-op if not present. */
+  async removeDir(path: string): Promise<void> {
+    const actionInfo = new ActionInfo('remove-dir', AgenticProcess.type, this.id, 'POST');
+    actionInfo.bodyParameters = { path };
+    await dataManager.callAction(actionInfo);
+    this.additional_dirs = (this.additional_dirs ?? []).filter((d) => d !== path);
   }
 
   async shell(): Promise<Shell | null> {
@@ -1490,24 +1502,14 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
       throw new Error('Process is stopping');
     }
 
-    // Fast path: if this process is already LIVE, its shell is cached, and the PTY is fully
-    // attached in this client, skip the backend `open` round-trip entirely. Tab switches
-    // between live sessions hit this path. Instructions must always go to the backend,
-    // so we only short-circuit when no instruction is provided.
-    // Requires the Shell entity to already be in cache AND its ptyConnection to be
-    // attached to the current pty_pid. That holds for repeat visits to a tab during
-    // the same app session; first visit still pays the full open + attach round-trip.
-    if (
-      this.status === ProcessStatus.RUNNING &&
-      this.shell_id &&
-      !options?.instruction
-    ) {
-      const cachedShell = dataManager.getByTypeIdFromCache<Shell>(new TypeId(Shell.type, this.shell_id));
-      if (cachedShell && cachedShell.pty_pid && cachedShell.ptyConnection?.isAttachedTo(cachedShell.pty_pid)) {
-        return true;
-      }
-    }
-
+    // No client-side lifecycle fast path. The backend ``open`` action is the
+    // single oracle for reattach-vs-recover-vs-fresh. The dedupe that *did*
+    // matter — "I'm already on this same pty_id, don't reopen the WS" — is
+    // already enforced inside ``PtyConnection.attach`` via the
+    // ``_attachedPtyId`` early-return and the in-flight ``_attachPromise``
+    // guard, so removing the short-circuit here costs nothing on tab-switch
+    // performance and removes the empty-shell-after-refresh failure mode
+    // (the cached ``status === RUNNING`` could outlive the actual worker).
     const actionInfo = new ActionInfo('open', AgenticProcess.type, this.id, 'POST');
     actionInfo.bodyParameters = options ?? {};
     const result = await dataManager.callAction<

--- a/ts_sdk/src/process/asset-descriptor.ts
+++ b/ts_sdk/src/process/asset-descriptor.ts
@@ -21,6 +21,8 @@ export interface AssetDescriptor {
   source: AssetSource;
   /** Canonical POSIX path; null for INLINE. */
   posix_path: string | null;
+  /** Matched source dir for path-discovered assets; null for EMBEDDED/INLINE. */
+  source_dir?: string | null;
 }
 
 /**

--- a/ts_sdk/src/stores/fsStore.ts
+++ b/ts_sdk/src/stores/fsStore.ts
@@ -286,7 +286,8 @@ export const fsStore = createStore<FSStoreState>()(
       // Deduplicate concurrent requests for the same path
       let pending = listDirInFlight.get(cacheKey);
       if (!pending) {
-        pending = fsManager.listDirectory(typeid, path).then((result) => {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const fetchPromise: Promise<BrowseCache> = fsManager.listDirectory(typeid, path).then((result) => {
           const entry: BrowseCache = {
             items: [...result.items],
             path: result.path,
@@ -294,14 +295,23 @@ export const fsStore = createStore<FSStoreState>()(
             itemCount: result.itemCount,
             fetchedAt: new Date(),
           };
-          set((state) => {
-            state.browseCache.set(cacheKey, entry as any);
-          });
+          // Only commit to cache if we are still the active in-flight fetch.
+          // If invalidate dropped us or a newer fetch replaced us, our result
+          // is stale and would clobber the fresh data.
+          if (listDirInFlight.get(cacheKey) === fetchPromise) {
+            set((state) => {
+              state.browseCache.set(cacheKey, entry as any);
+            });
+          }
           return entry;
         }).finally(() => {
-          listDirInFlight.delete(cacheKey);
+          // Only clear our own slot, not a successor's
+          if (listDirInFlight.get(cacheKey) === fetchPromise) {
+            listDirInFlight.delete(cacheKey);
+          }
         });
-        listDirInFlight.set(cacheKey, pending);
+        listDirInFlight.set(cacheKey, fetchPromise);
+        pending = fetchPromise;
       }
 
       return pending;
@@ -633,6 +643,10 @@ export const fsStore = createStore<FSStoreState>()(
         }
         if (cacheType === 'browse' || cacheType === 'all') {
           state.browseCache.delete(cacheKey);
+          // Drop any in-flight listDirectory promise too — otherwise the next
+          // listDirectory call would dedup onto a request whose result was
+          // captured before invalidation and overwrite the cache with stale data.
+          listDirInFlight.delete(cacheKey);
         }
       });
     },

--- a/ui/src/components/asset-manager/AssetManagerPopover.tsx
+++ b/ui/src/components/asset-manager/AssetManagerPopover.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import {
   AgenticProcess,
   ASSET_SOURCE_LABEL,
   dataManager,
   isReadOnlySource,
   isTypeId,
+  Project,
+  QueryRequest,
   TypeId,
   type AssetDescriptor,
   type AssetSource,
@@ -14,13 +16,21 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@src/components/ui/popover';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@src/components/ui/dropdown-menu';
+import { useContext as useDataContext } from '@src/hooks/useContext';
+import { useEntitiesQuery } from '@src/hooks/entity-hooks';
 import { useProcessAssets } from './useProcessAssets';
 import { useAssetTypes, type AssetTypeInfo } from '@src/hooks/use-asset-types';
 import { lucideByName } from '@src/lib/lucide-by-name';
 import { ICON_BY_TYPE } from '@src/components/conversation/EntityChip';
 import { DockPointer } from '@src/navigation/DockPointer';
 import { useDockNavigation } from '@src/navigation/useDockNavigation';
-import { ArrowLeft, Boxes, Lock, Plus, X, type LucideIcon } from 'lucide-react';
+import { ArrowLeft, ArrowDownAZ, Boxes, Folder, FolderOpen, FolderPlus, Lock, Plus, Search, X, type LucideIcon } from 'lucide-react';
 
 const READONLY_TOOLTIP_BY_SOURCE: Partial<Record<AssetSource, string>> = {
   project_dir: 'Defined in the project — edits propagate to every process under this project. Attach to get a private editable copy.',
@@ -59,11 +69,78 @@ export function AssetManagerPopover({
   footer,
 }: AssetManagerPopoverProps) {
   const [open, setOpen] = useState(false);
-  const [mode, setMode] = useState<'list' | 'add'>('list');
+  const [mode, setMode] = useState<'list' | 'add' | 'pick-project'>('list');
   const [query, setQuery] = useState('');
+  const [listFilter, setListFilter] = useState('');
+  const [sortBy, setSortBy] = useState<'source' | 'name'>('source');
 
   const { descriptors, refresh } = useProcessAssets(process, { enabled: open });
   const { types: assetTypes } = useAssetTypes();
+
+  const dataCtx = useDataContext();
+
+  // Subscribe to entity-field changes (additional_dirs, restart_required, …) so
+  // the popover re-renders when the backend mutates them in place.
+  useSyncExternalStore(
+    useCallback(
+      (cb) => (process ? dataManager.subscribe(process.typeId, cb, false) : () => {}),
+      [process],
+    ),
+    () => (process ? process.restart_required : false),
+    () => (process ? process.restart_required : false),
+  );
+
+  const additionalDirs = process?.additional_dirs ?? [];
+
+  // When restart_required transitions from true → false (a successful restart
+  // just completed) re-fetch descriptors so the list reflects the new worker
+  // state — e.g. embedded assets that were materialized on start.
+  const prevRestartRequired = useRef<boolean>(false);
+  useEffect(() => {
+    if (!process) return;
+    const cur = !!process.restart_required;
+    if (prevRestartRequired.current && !cur && open) {
+      void refresh();
+    }
+    prevRestartRequired.current = cur;
+  }, [process, process?.restart_required, open, refresh]);
+
+  // Project picker — load once when entering pick-project mode.
+  const projectsQuery = useMemo(() => new QueryRequest({ type: Project.type }), []);
+  const { data: allProjects = [] } = useEntitiesQuery<Project>(projectsQuery, {
+    enabled: open && mode === 'pick-project',
+  });
+  const [projectQuery, setProjectQuery] = useState('');
+
+  const handleAddFolder = useCallback(async () => {
+    if (!process) return;
+    const cn = dataCtx.computeNode;
+    if (!cn) return;
+    const picked = await cn.openPathDialog();
+    if (!picked) return;
+    await process.addDir(picked);
+    await refresh();
+  }, [process, dataCtx.computeNode, refresh]);
+
+  const handlePickProject = useCallback(
+    async (path: string) => {
+      if (!process || !path) return;
+      await process.addDir(path);
+      setMode('list');
+      setProjectQuery('');
+      await refresh();
+    },
+    [process, refresh],
+  );
+
+  const handleRemoveDir = useCallback(
+    async (path: string) => {
+      if (!process) return;
+      await process.removeDir(path);
+      await refresh();
+    },
+    [process, refresh],
+  );
 
   // Pre-fetch every descriptor's entity into the dataManager cache so the
   // chip text resolves to ``entity.displayName`` (typeid → real name) on
@@ -110,15 +187,54 @@ export function AssetManagerPopover({
   // inside the row component).
   const rows = useMemo(() => {
     void entityVersion;
-    return [...descriptors].sort((a, b) => {
-      // EMBEDDED first, then by source label, then by name suffix.
+    const q = listFilter.trim().toLowerCase();
+    const filtered = q
+      ? descriptors.filter((d) => {
+          const label = _displayLabelForTypeid(d.typeid).toLowerCase();
+          return (
+            label.includes(q) ||
+            d.typeid.toLowerCase().includes(q) ||
+            d.source.toLowerCase().includes(q) ||
+            (d.posix_path ?? '').toLowerCase().includes(q) ||
+            (d.source_dir ?? '').toLowerCase().includes(q)
+          );
+        })
+      : descriptors;
+    return [...filtered].sort((a, b) => {
+      if (sortBy === 'name') {
+        const la = _displayLabelForTypeid(a.typeid).toLowerCase();
+        const lb = _displayLabelForTypeid(b.typeid).toLowerCase();
+        if (la !== lb) return la.localeCompare(lb);
+        return a.source.localeCompare(b.source);
+      }
+      // Default: EMBEDDED first, then by source label, then by name suffix.
       const sa = a.source === 'embedded' ? 0 : 1;
       const sb = b.source === 'embedded' ? 0 : 1;
       if (sa !== sb) return sa - sb;
       if (a.source !== b.source) return a.source.localeCompare(b.source);
       return a.typeid.localeCompare(b.typeid);
     });
-  }, [descriptors, entityVersion]);
+  }, [descriptors, entityVersion, listFilter, sortBy]);
+
+  const filteredDirs = useMemo(() => {
+    const q = listFilter.trim().toLowerCase();
+    if (!q) return additionalDirs;
+    return additionalDirs.filter((p) => p.toLowerCase().includes(q));
+  }, [additionalDirs, listFilter]);
+
+  const filteredProjects = useMemo(() => {
+    const q = projectQuery.trim().toLowerCase();
+    const list = allProjects.filter((p) => {
+      const path = (p as { fs_storage_mount_path?: string }).fs_storage_mount_path;
+      return !!path; // hide projects without a mount path
+    });
+    if (!q) return list;
+    return list.filter((p) => {
+      const name = (p.displayName ?? '').toLowerCase();
+      const path = ((p as { fs_storage_mount_path?: string }).fs_storage_mount_path ?? '').toLowerCase();
+      return name.includes(q) || path.includes(q);
+    });
+  }, [allProjects, projectQuery]);
 
   // Add-mode entries: anything not currently EMBEDDED. Each row is the
   // "source" copy that the user can attach to the process.
@@ -141,6 +257,8 @@ export function AssetManagerPopover({
       if (!next) {
         setMode('list');
         setQuery('');
+        setProjectQuery('');
+        setListFilter('');
       }
     },
     [refresh],
@@ -164,7 +282,7 @@ export function AssetManagerPopover({
       >
         {/* Header */}
         <div className="flex items-center gap-1.5 border-b px-3 py-2">
-          {mode === 'add' && (
+          {mode !== 'list' && (
             <button
               type="button"
               className="-ml-1 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-muted"
@@ -177,16 +295,90 @@ export function AssetManagerPopover({
           )}
           <Boxes className="h-3.5 w-3.5 text-muted-foreground" />
           <span className="text-xs font-medium">
-            {mode === 'add' ? 'Add asset' : 'Assets'}
+            {mode === 'add'
+              ? 'Add asset'
+              : mode === 'pick-project'
+              ? 'Pick project folder'
+              : 'Assets'}
           </span>
+          {mode === 'list' && (
+            <div className="ml-auto flex items-center">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    title="Add"
+                    className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                    data-testid="asset-manager-add-menu"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  <DropdownMenuItem
+                    onSelect={() => setMode('add')}
+                    data-testid="asset-manager-add-asset"
+                  >
+                    <Boxes className="mr-2 h-3.5 w-3.5" />
+                    Asset…
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={!process || !dataCtx.computeNode}
+                    onSelect={() => { void handleAddFolder(); }}
+                    data-testid="asset-manager-add-folder"
+                  >
+                    <FolderOpen className="mr-2 h-3.5 w-3.5" />
+                    Folder…
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={!process}
+                    onSelect={() => { setProjectQuery(''); setMode('pick-project'); }}
+                    data-testid="asset-manager-add-project-folder"
+                  >
+                    <FolderPlus className="mr-2 h-3.5 w-3.5" />
+                    Project folder…
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
         </div>
 
         {mode === 'list' ? (
           <>
-            <div data-testid="asset-manager-list">
-              {rows.length === 0 && (
+            <div className="flex items-center gap-1.5 border-b bg-muted/20 px-2 py-1.5">
+              <Search className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Filter…"
+                value={listFilter}
+                onChange={(e) => setListFilter(e.target.value)}
+                className="min-w-0 flex-1 rounded border bg-background px-1.5 py-0.5 text-[11px] outline-none focus:ring-1 focus:ring-ring"
+                data-testid="asset-manager-list-filter"
+              />
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as 'source' | 'name')}
+                className="rounded border bg-background px-1 py-0.5 text-[11px] outline-none focus:ring-1 focus:ring-ring"
+                title="Sort"
+                data-testid="asset-manager-list-sort"
+              >
+                <option value="source">By source</option>
+                <option value="name">By name</option>
+              </select>
+              <ArrowDownAZ className="h-3 w-3 flex-shrink-0 text-muted-foreground" aria-hidden />
+            </div>
+            <div className="max-h-80 overflow-y-auto" data-testid="asset-manager-list">
+              {filteredDirs.map((path) => (
+                <DirRow
+                  key={`dir|${path}`}
+                  path={path}
+                  onRemove={handleRemoveDir}
+                />
+              ))}
+              {rows.length === 0 && filteredDirs.length === 0 && (
                 <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
-                  No assets visible to this process.
+                  {listFilter.trim() ? 'No matches.' : 'No assets visible to this process.'}
                 </div>
               )}
               {rows.map((d, idx) => (
@@ -198,20 +390,11 @@ export function AssetManagerPopover({
                   onDetach={onDetach}
                 />
               ))}
-              <button
-                type="button"
-                className="flex w-full items-center gap-2 border-b bg-muted/30 px-3 py-2 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-                onClick={() => setMode('add')}
-                data-testid="asset-manager-add"
-              >
-                <Plus className="h-3.5 w-3.5" />
-                Attach asset
-              </button>
             </div>
 
             {footer}
           </>
-        ) : (
+        ) : mode === 'add' ? (
           <div>
             <div className="border-b px-3 py-2">
               <input
@@ -241,6 +424,38 @@ export function AssetManagerPopover({
               ))}
             </div>
           </div>
+        ) : (
+          <div>
+            <div className="border-b px-3 py-2">
+              <input
+                autoFocus
+                type="text"
+                placeholder="Search projects…"
+                value={projectQuery}
+                onChange={(e) => setProjectQuery(e.target.value)}
+                className="w-full rounded-md border bg-background px-2 py-1 text-xs outline-none focus:ring-1 focus:ring-ring"
+                data-testid="asset-manager-project-search"
+              />
+            </div>
+            <div className="max-h-80 overflow-y-auto">
+              {filteredProjects.length === 0 && (
+                <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+                  No projects.
+                </div>
+              )}
+              {filteredProjects.map((p) => {
+                const path = (p as { fs_storage_mount_path?: string }).fs_storage_mount_path ?? '';
+                return (
+                  <ProjectPickRow
+                    key={p.id}
+                    name={p.displayName ?? p.id ?? ''}
+                    path={path}
+                    onPick={handlePickProject}
+                  />
+                );
+              })}
+            </div>
+          </div>
         )}
       </PopoverContent>
     </Popover>
@@ -253,6 +468,75 @@ function _parseTypeid(typeid: string): { type: string; id: string } {
   const dash = typeid.indexOf('-');
   if (dash < 0) return { type: typeid, id: '' };
   return { type: typeid.slice(0, dash), id: typeid.slice(dash + 1) };
+}
+
+function _basename(path: string): string {
+  const trimmed = path.replace(/\/+$/, '');
+  const slash = trimmed.lastIndexOf('/');
+  return slash >= 0 ? trimmed.slice(slash + 1) : trimmed;
+}
+
+function DirRow({
+  path,
+  onRemove,
+}: {
+  path: string;
+  onRemove: (path: string) => void | Promise<void>;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2 border-b px-3 py-1.5 last:border-b-0"
+      data-testid={`asset-manager-dir-row-${path}`}
+    >
+      <Folder className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+      <span
+        className="min-w-0 flex-1 truncate text-xs text-foreground"
+        title={path}
+      >
+        {_basename(path) || path}
+      </span>
+      <span
+        className="flex-shrink-0 rounded border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+        title={path}
+      >
+        {ASSET_SOURCE_LABEL.additional_dir}
+      </span>
+      <button
+        type="button"
+        className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+        onClick={() => void onRemove(path)}
+        title="Remove directory"
+        data-testid={`asset-manager-dir-remove-${path}`}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+function ProjectPickRow({
+  name,
+  path,
+  onPick,
+}: {
+  name: string;
+  path: string;
+  onPick: (path: string) => void | Promise<void>;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center gap-2 border-b px-3 py-1.5 text-left last:border-b-0 hover:bg-muted/50"
+      onClick={() => void onPick(path)}
+      data-testid={`asset-manager-project-pick-${path}`}
+    >
+      <FolderPlus className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs text-foreground" title={name}>{name}</div>
+        <div className="truncate text-[10px] text-muted-foreground" title={path}>{path}</div>
+      </div>
+    </button>
+  );
 }
 
 /**
@@ -312,9 +596,13 @@ function AssetRow({
   }, [navigation, type, id, readOnly]);
 
   const sourceLabel = ASSET_SOURCE_LABEL[descriptor.source];
-  const sourceTooltip = descriptor.posix_path
-    ? `${sourceLabel}\n${descriptor.posix_path}`
-    : `${sourceLabel}\n(no file — inline persona)`;
+  const sourceDirBasename = descriptor.source_dir ? _basename(descriptor.source_dir) : null;
+  const sourcePillText = sourceDirBasename ? `${sourceLabel} · ${sourceDirBasename}` : sourceLabel;
+  const sourceTooltip = [
+    sourceLabel,
+    descriptor.source_dir ? `from: ${descriptor.source_dir}` : null,
+    descriptor.posix_path ?? '(no file — inline persona)',
+  ].filter(Boolean).join('\n');
   const lockTooltip = READONLY_TOOLTIP_BY_SOURCE[descriptor.source] ?? 'Read-only from this process. Attach to get a private editable copy.';
 
   return (
@@ -342,11 +630,11 @@ function AssetRow({
         </Lock>
       )}
       <span
-        className="flex-shrink-0 rounded border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+        className="max-w-[140px] flex-shrink-0 truncate rounded border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
         title={sourceTooltip}
         data-testid={`asset-manager-source-${descriptor.typeid}-${descriptor.source}`}
       >
-        {sourceLabel}
+        {sourcePillText}
       </span>
       {attached && !readOnly && (
         <button

--- a/ui/src/components/assets/editor/markdown/MarkdownEditor.tsx
+++ b/ui/src/components/assets/editor/markdown/MarkdownEditor.tsx
@@ -7,8 +7,9 @@ import { useMarkdownContent } from '@src/hooks/use-markdown-content';
 import { DockPointer } from '@src/navigation/DockPointer';
 import { useDockNavigation } from '@src/navigation/useDockNavigation';
 import { FSRef } from '@sdk';
+import { downloadFile } from '@sdk/utils/utils';
 import Editor, { type OnMount } from '@monaco-editor/react';
-import { ChevronDown, ChevronRight, Eye, ExternalLink, FileCode, MessageSquareDiff, Pencil, RefreshCw } from 'lucide-react';
+import { ChevronDown, ChevronRight, Download, Eye, ExternalLink, FileCode, MessageSquareDiff, Pencil, RefreshCw } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -156,8 +157,15 @@ function MarkdownEditorContent({
   const dirPath = sourcePath.slice(0, sourcePath.lastIndexOf('/'));
 
   const handleOpenExternal = useCallback(() => {
-    navigator.clipboard.writeText(sourcePath).catch(() => {});
-  }, [sourcePath]);
+    void fsRef.open({ select: true });
+  }, [fsRef]);
+
+  const handleDownload = useCallback(() => {
+    void (async () => {
+      const content = await fsRef.read();
+      downloadFile({ name: fileName, content: new Blob([content], { type: 'text/markdown' }) });
+    })();
+  }, [fsRef, fileName]);
 
   const handleLinkClick = useCallback((href: string) => {
     // /dock/assets/wiki/<name> → keep the URL at the wiki form; the
@@ -186,6 +194,7 @@ function MarkdownEditorContent({
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           onOpenExternal={handleOpenExternal}
+          onDownload={handleDownload}
           actions={toolbar}
         />
         <div className="flex flex-1 items-center justify-center">
@@ -206,6 +215,7 @@ function MarkdownEditorContent({
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           onOpenExternal={handleOpenExternal}
+          onDownload={handleDownload}
           actions={toolbar}
         />
         <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
@@ -229,6 +239,7 @@ function MarkdownEditorContent({
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         onOpenExternal={handleOpenExternal}
+        onDownload={handleDownload}
         actions={toolbar}
       />
 
@@ -374,10 +385,11 @@ interface EditorHeaderProps {
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
   onOpenExternal: () => void;
+  onDownload?: () => void;
   actions?: React.ReactNode;
 }
 
-function EditorHeader({ fileName, dirPath, dirty, viewMode, onViewModeChange, onOpenExternal, actions }: EditorHeaderProps) {
+function EditorHeader({ fileName, dirPath, dirty, viewMode, onViewModeChange, onOpenExternal, onDownload, actions }: EditorHeaderProps) {
   return (
     <div className="flex h-[52px] flex-shrink-0 items-center gap-2 border-b px-3">
       <div className="min-w-0 flex-1">
@@ -385,9 +397,29 @@ function EditorHeader({ fileName, dirPath, dirty, viewMode, onViewModeChange, on
           <span className="text-sm font-medium">{fileName}</span>
           {dirty && <span className="text-sm text-amber-500">*</span>}
         </div>
-        {dirPath && (
-          <div className="truncate text-[11px] text-muted-foreground">{dirPath}</div>
-        )}
+        <div className="flex min-w-0 items-center gap-1">
+          {dirPath && (
+            <span className="min-w-0 truncate text-[11px] text-muted-foreground">{dirPath}</span>
+          )}
+          <button
+            title="Reveal in Finder"
+            onClick={onOpenExternal}
+            data-testid="markdown-editor-open-external"
+            className="flex-shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </button>
+          {onDownload && (
+            <button
+              title="Download file"
+              onClick={onDownload}
+              data-testid="markdown-editor-download"
+              className="flex-shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <Download className="h-3 w-3" />
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="flex flex-shrink-0 items-center rounded-md border bg-muted/40 p-0.5">
@@ -413,14 +445,6 @@ function EditorHeader({ fileName, dirPath, dirty, viewMode, onViewModeChange, on
       </div>
 
       {actions && <div className="flex flex-shrink-0 items-center gap-1">{actions}</div>}
-
-      <button
-        title="Copy path to clipboard"
-        onClick={onOpenExternal}
-        className="flex-shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-      >
-        <ExternalLink className="h-4 w-4" />
-      </button>
     </div>
   );
 }

--- a/ui/src/components/live-workflow/SessionTabBar.tsx
+++ b/ui/src/components/live-workflow/SessionTabBar.tsx
@@ -113,13 +113,8 @@ export function SessionTabBar({
     await onCloseTab(sessionId);
   };
 
-  // Handle click on name to start editing
-  const handleTabNameClick = (e: React.MouseEvent, sessionId: string, currentName: string, isActive: boolean) => {
-    e.stopPropagation();
-    if (!isActive) {
-      handleTabClick(sessionId);
-      return;
-    }
+  // Enter rename mode (double-click on tab title)
+  const handleTabNameDoubleClick = (sessionId: string, currentName: string) => {
     setEditingSessionId(sessionId);
     setEditingName(currentName);
   };
@@ -230,7 +225,10 @@ export function SessionTabBar({
               ) : (
                 <span
                   className="max-w-[150px] truncate text-sm font-medium"
-                  onClick={(e) => session.id && handleTabNameClick(e, session.id, displayName, isActive)}
+                  onDoubleClick={(e) => {
+                    e.stopPropagation();
+                    if (session.id) handleTabNameDoubleClick(session.id, displayName);
+                  }}
                 >
                   {displayName}
                 </span>

--- a/ui/src/components/terminal/TabbedTerminal.tsx
+++ b/ui/src/components/terminal/TabbedTerminal.tsx
@@ -26,7 +26,6 @@ import {
   Loader2,
   SquareTerminal,
   X,
-  XCircle,
 } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { HistoryModal } from './HistoryModal';
@@ -880,23 +879,27 @@ const TabbedTerminal: React.FC<TabbedTerminalProps> = ({
             </Button>
           )}
 
-          {/* Close All button — shown when 2+ tabs are open */}
+          {/* Close All button — shown when 2+ tabs are open. Tab count badge
+              hints at the destructive scope before clicking. */}
           {visibleSessions.length >= 2 && (
             <TooltipProvider delayDuration={600}>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 shrink-0 rounded-none text-muted-foreground hover:text-destructive"
+                    variant="outline"
+                    size="sm"
+                    className="mx-1.5 h-6 shrink-0 gap-1.5 rounded-md border-border bg-background px-2 text-foreground shadow-sm hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive"
                     onClick={handleCloseAll}
-                    aria-label="Close all tabs"
+                    aria-label={`Close all ${visibleSessions.length} tabs`}
                     data-testid="close-all-tabs-button"
                   >
-                    <XCircle className="h-4 w-4" />
+                    <X className="h-3.5 w-3.5" />
+                    <span className="inline-flex h-4 min-w-[1.125rem] items-center justify-center rounded-full bg-foreground/10 px-1 text-[10px] font-semibold leading-none tabular-nums text-foreground">
+                      {visibleSessions.length}
+                    </span>
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">Close all tabs</TooltipContent>
+                <TooltipContent side="bottom">Close all {visibleSessions.length} tabs</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}

--- a/ui/src/components/terminal/interactive-terminal/side-windows/InputFilesPanel.tsx
+++ b/ui/src/components/terminal/interactive-terminal/side-windows/InputFilesPanel.tsx
@@ -1,7 +1,7 @@
 import { type TypeId } from '@sdk';
 import { fsStore } from '@sdk';
 import { openExternalFromComputeNode } from '@sdk/entities/compute-node';
-import { ExternalLink, File, RefreshCw } from 'lucide-react';
+import { ExternalLink, File, RefreshCw, Trash2 } from 'lucide-react';
 import React, { useState, useEffect } from 'react';
 import { Button } from '@src/components/ui/button';
 import {
@@ -36,18 +36,24 @@ export const InputFilesPanel: React.FC<InputFilesPanelProps> = ({
   const fsRef = React.useRef(fs);
   fsRef.current = fs;
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
-  const [refreshKey, setRefreshKey] = useState(0);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [deletingPath, setDeletingPath] = useState<string | null>(null);
 
+  const browseResult = fs?.browse(inputDirAbsPath);
+  const items = browseResult?.items ?? [];
+
+  // Fetch whenever the cache has no entry for this path. This covers initial
+  // mount and any later invalidation triggered by upload/delete elsewhere in
+  // the app — listDirectory dedupes concurrent calls, so spurious fires are
+  // cheap. fs is read via ref because useFS returns a new object each render.
   useEffect(() => {
-    if (!fsRef.current) return;
-    void fsRef.current.listDirectory(inputDirAbsPath);
-  }, [inputDirAbsPath, refreshKey]);
+    if (browseResult) return;
+    void fsRef.current?.listDirectory(inputDirAbsPath);
+  }, [browseResult, inputDirAbsPath]);
 
   const handleRefresh = () => {
     if (!fs) return;
     fs.invalidate(inputDirAbsPath, 'browse');
-    setRefreshKey((k) => k + 1);
   };
 
   const handleDragOver = (e: React.DragEvent) => {
@@ -73,8 +79,15 @@ export const InputFilesPanel: React.FC<InputFilesPanelProps> = ({
     await Promise.all(uploads.map((u) => u.waitForCompletion()));
   };
 
-  const browseResult = fs?.browse(inputDirAbsPath);
-  const items = browseResult?.items ?? [];
+  const handleDelete = async (path: string) => {
+    if (!fs) return;
+    setDeletingPath(path);
+    try {
+      await fs.delete(path);
+    } finally {
+      setDeletingPath(null);
+    }
+  };
 
   return (
     <div
@@ -103,12 +116,14 @@ export const InputFilesPanel: React.FC<InputFilesPanelProps> = ({
         ) : (
           <div className="flex flex-col gap-1">
             {items.map((item) => {
-              const downloadUrl = fs?.getDownloadUrl(item.vfs_abs_path ?? `${inputDirAbsPath}/${item.name}`);
+              const itemPath = `${inputDirAbsPath}/${item.name}`;
+              const downloadUrl = fs?.getDownloadUrl(item.vfs_abs_path ?? itemPath);
               const isImage = isImageFile(item.name);
+              const isDeleting = deletingPath === itemPath;
               return (
                 <div
                   key={item.name}
-                  className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm ${isImage ? 'cursor-pointer hover:bg-muted' : 'hover:bg-muted/50'}`}
+                  className={`group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm ${isImage ? 'cursor-pointer hover:bg-muted' : 'hover:bg-muted/50'} ${isDeleting ? 'opacity-50' : ''}`}
                   onClick={isImage && downloadUrl ? () => setSelectedImage(downloadUrl) : undefined}
                 >
                   {isImage && downloadUrl ? (
@@ -126,6 +141,20 @@ export const InputFilesPanel: React.FC<InputFilesPanelProps> = ({
                       <p className="text-[10px] text-muted-foreground">{formatSize(item.size)}</p>
                     )}
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 shrink-0 p-0 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+                    aria-label={`Delete ${item.name}`}
+                    title={`Delete ${item.name}`}
+                    disabled={isDeleting}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void handleDelete(itemPath);
+                    }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary

- **Open-lock**: per-process asyncio.Lock around the `start`/`open` lifecycle so two concurrent refresh-driven open calls (two browser tabs hitting the same process) can't both run recovery and double-spawn Claude.
- **`AssetDescriptor.source_dir`**: surfaces which source dir a path-discovered asset came from (None for EMBEDDED/INLINE); displayed in AssetManagerPopover.
- **Auto-index added dirs**: when a dir is added to `additional_dirs`, run a one-shot indexer scan (CWD_ROOT, `include_temp=True`) so its skills/agents become discoverable via `Entity.assets_by_path`. Best-effort + silent on failure.
- **AssetManagerPopover revamp** (~+340 LOC): source-dir display, filtering, clearer source labels; smaller refinements to MarkdownEditor / SessionTabBar / TabbedTerminal / InputFilesPanel.
- **Docs**: agent-management/{agent-records,agentic-process}.md regenerated to match.
- **New skills**: `.claude/agents/pyrate.md`, `.claude/skills/demos/SKILL.md`.

## Test plan

- [ ] Open the same AgenticProcess in two browser tabs simultaneously — confirm only one Claude PTY spawns
- [ ] Add a fresh dir containing a skill to `additional_dirs` — confirm the skill appears under the source_dir badge in AssetManagerPopover
- [ ] `uv run pytest tests/unit/test_agentic_process_get_assets.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)