### PR TITLE
v0.2.19 fixes: skill bottom chat, os-status, project-scoped tabs, auto-recovery dispatcher

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,29 +1,20 @@
-# Frontend redirect URL after a successful login.
-LOGIN_URL=/login?target_path={redirect_url}
-
 # Hub/cloud base URL the backend talks to. Switch to staging.flowpad.ai for staging.
 #FLOWPAD_HUB_URL=https://staging.flowpad.ai
 FLOWPAD_HUB_URL=http://localhost:8093
 
-# Local backend HTTP port (uvicorn).
+# Local backend port. Frontend derives http://localhost:$LOCAL_SERVER_PORT for its API base.
 LOCAL_SERVER_PORT=9008
 
 # Frontend dev server port (vite).
 VITE_PORT=4098
 
-# Backend URL the frontend calls — should match LOCAL_SERVER_PORT above.
-VITE_API_URL=http://localhost:9008
-
-# SQLite DB file path. Use /tmp for an ephemeral dev DB.
+# SQLite DB path. /tmp = ephemeral; unset falls back to ~/.flow/dev_db/flowpad_db.
 SQLITE_DATABASE_PATH=/tmp/flowpad_dev.db
 
-# Enables dev-instance dirs, dev plugin discovery, and SQLite dev quirks.
+# Dev mode — enables dev instance dirs, plugin discovery, SQLite quirks, and the UI dev toolbar.
 FLOWPAD_DEV=true
 
-# Frontend dev-mode toolbar. Must be the literal string "true" to enable.
-VITE_DEV_MODE=true
-
-# Uvicorn auto-reload on Python file changes (orthogonal to FLOWPAD_DEV).
+# Uvicorn auto-reload. Kept separate from FLOWPAD_DEV — Electron hardcodes false.
 MINIHUB_RELOAD=True
 
 # Env-mode auto-login: when both are set, the UI's "log in" POSTs these to FLOWPAD_HUB_URL/api/v1/login.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,30 @@
+---
+asset_id: "8762a20a-148a-4780-a05a-7a4c48c245dc"
+title: "intro"
+---
+
+# Flowpad 
+
+Flowpad is a way to assist or get assisted on AI work on our computer in secured, simple and AI native way - the Zoom for AI work.  
+
+## What is Flowpad ? 
+
+Flowpad is a tool for collaborative AI work addressing one of the most critical gaps in today's AI eco-system - How does a team of human workers and AI workers collaborate securely, privately and efficiently. 
+
+The most basic way to use Flowpad is its collaborative context conversation, where a knowledge worker can share teammate, in real time, their agent work - cli, codex, co-work or cursor for the purpose of assistance, support, guidance, status and more where each participant in the conversation can inject and query the agent context with a click, given the other side ask. 
+
+<br />
+
+## Use cases:
+
+Product and Architecture - Leaders create and share Specs, Developers use it with a click, status is automatically communicated seamlessly. 
+
+Forward deployment engineering - In today's world, AI enterprise sales requires FDE - Flowpad allows super fast Team-FDE-Customer collaboration 
+
+Solution engineering -  from customer call to working integrations and data pipelines in minutes. 
+
+Junior guidance and monitoring - Juniors get Architecture proof plans, Their work is auto reviewed along the way, allowing them to deliver with success. 
+
+<br />
+
+##

--- a/flow_sdk/builtin/agentic_process/agentic_process.py
+++ b/flow_sdk/builtin/agentic_process/agentic_process.py
@@ -14,6 +14,7 @@ import json
 import logging
 import time
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
@@ -2157,6 +2158,95 @@ class AgenticProcess(Entity):
         result = await self.start(instruction=instruction, visible=visible)
         _http_bench("after start() return")
         return result
+
+    @action.get(action_name="os-status")
+    async def os_status(self) -> ApiSuccessResponse:
+        """OS-level status snapshot for this AgenticProcess.
+
+        Single source of truth for "is this thing alive?". Combines:
+          - Persisted entity status (process + linked shell records).
+          - In-memory PTY-session liveness on the bound compute node.
+          - Real PID liveness check on the worker (psutil + cmdline match).
+
+        ``ready`` is the headline: True iff the PTY session is alive AND the
+        worker PID matches the recorded ``--session-id``/``--resume`` value.
+        It's the answer the frontend ``AgenticProcess.isAlive()`` returns.
+
+        Read-only with respect to lifecycle. ``has_attachable_pty`` /
+        ``worker_alive`` may opportunistically rebind a stale compute-node
+        link (self-healing), but never spawns or kills anything.
+        """
+        shell = await self.shell() if self.shell_id else None
+
+        pty_alive = False
+        worker_is_alive = False
+        has_attachable = False
+        pty_pid: int | None = None
+        worker_pid: int | None = None
+        worker_name: str | None = None
+        shell_status: str | None = None
+
+        if shell is not None:
+            shell_status = shell.status
+            worker_pid = shell.worker_pid
+            worker_name = shell.worker_name
+            try:
+                has_attachable = await shell.has_attachable_pty()
+            except Exception as exc:
+                logger.warning("os_status: has_attachable_pty failed for %s: %s", self.id, exc)
+                has_attachable = False
+            try:
+                pty_alive = bool(shell.is_alive)
+            except Exception:
+                pty_alive = False
+            try:
+                worker_is_alive = await shell.worker_alive()
+            except RuntimeError:
+                # ``worker_alive`` raises when the PTY exists but its session
+                # is dead — for a status read we treat that as "not alive".
+                worker_is_alive = False
+            except Exception as exc:
+                logger.warning("os_status: worker_alive failed for %s: %s", self.id, exc)
+                worker_is_alive = False
+            if shell.compute_node_id:
+                try:
+                    cn = shell.compute_node
+                    pty_pid_val = cn.compute_provider.get_pty_shell_pid(cn.node_provider_id, shell.id)
+                    pty_pid = int(pty_pid_val) if pty_pid_val is not None else None
+                except Exception:
+                    pty_pid = None
+
+        ready = has_attachable and worker_is_alive
+
+        if ready:
+            reason = None
+        elif not self.shell_id:
+            reason = "no shell linked to process"
+        elif shell is None:
+            reason = f"shell {self.shell_id} not found"
+        elif not has_attachable:
+            reason = "pty session not attachable"
+        elif not worker_is_alive:
+            reason = "worker pid not alive or cmdline mismatch"
+        else:
+            reason = None
+
+        return ApiSuccessResponse(data={
+            "process_id": self.id,
+            "process_status": self.status,
+            "shell_id": self.shell_id,
+            "shell_status": shell_status,
+            "session_id": self.session_id,
+            "pty_pid": pty_pid,
+            "worker_pid": worker_pid,
+            "worker_name": worker_name,
+            "pty_alive": pty_alive,
+            "worker_alive": worker_is_alive,
+            "has_attachable_pty": has_attachable,
+            "ready": ready,
+            "reason": reason,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        })
 
     @action.post(action_name="close")
     async def _http_close(self) -> ApiSuccessResponse | ApiFailResponse:

--- a/flow_sdk/builtin/agentic_process/agentic_process.py
+++ b/flow_sdk/builtin/agentic_process/agentic_process.py
@@ -1390,6 +1390,42 @@ class AgenticProcess(Entity):
         await self.save()
         return ApiSuccessResponse(data={"ok": True, "name": agent.name})
 
+    @action.post(action_name="load-embedded-skill")
+    async def load_embedded_skill_action(self, asset_ref: str = "") -> "ApiSuccessResponse | ApiFailResponse":
+        """Symlink a skill folder into this process's assets dir.
+
+        Skills are directory-discovered by Claude Code at startup, not a CLI
+        input. We symlink the live source folder under
+        ``<assets_dir>/.claude/skills/<name>/`` so edits to the original SKILL.md
+        flow through to the next chat without re-materialization.
+        """
+        import shutil
+        if not asset_ref:
+            return ApiFailResponse(message="asset_ref is required")
+        skill_dir = Path("/" + asset_ref.lstrip("/")).resolve()
+        if not skill_dir.is_dir():
+            return ApiFailResponse(message=f"Skill folder not found: {skill_dir}")
+        if not (skill_dir / "SKILL.md").exists():
+            return ApiFailResponse(message=f"SKILL.md missing in: {skill_dir}")
+        try:
+            assets_dir = await self._assets_dir_path()
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            skills_root = assets_dir / ".claude" / "skills"
+            skills_root.mkdir(parents=True, exist_ok=True)
+            link = skills_root / skill_dir.name
+            # Refresh: a stale symlink, prior copy, or regular file all get replaced.
+            if link.is_symlink() or link.is_file():
+                link.unlink()
+            elif link.is_dir():
+                shutil.rmtree(link)
+            link.symlink_to(skill_dir, target_is_directory=True)
+            self._ensure_assets_dir_in_add_dirs(assets_dir)
+            await self.save()
+            return ApiSuccessResponse(data={"ok": True, "name": skill_dir.name, "link": str(link)})
+        except Exception as exc:
+            logger.exception("load_embedded_skill failed for %s", asset_ref)
+            return ApiFailResponse(message=str(exc))
+
     def load_embedded_agent(self, agent: "Any") -> None:
         """Embed an agent into this process so it is registered via --agents at launch.
 

--- a/flow_sdk/fs_records/markdown_record.py
+++ b/flow_sdk/fs_records/markdown_record.py
@@ -6,6 +6,7 @@ Supports discovery of .md files across a project directory.
 
 from __future__ import annotations
 
+import functools
 import os
 import re
 import uuid
@@ -56,27 +57,57 @@ def _find_docs_subdirs(root: Path) -> list[Path]:
     return found
 
 
-def _doc_search_dirs() -> list[Path]:
-    """Return directories to scan for doc .md files.
+def _doc_search_dirs() -> tuple[Path, ...]:
+    """Return resolved directories to scan for doc .md files.
 
     Scans user-level (~/.claude/docs), all known Claude projects
     (every 'docs' directory anywhere in each project tree, plus
     <project>/docs and <project>/.claude/docs for back-compat),
     cwd-level, and any extra dirs from FLOWPAD_DOC_DIRS
-    (colon-separated).
+    (colon-separated). Returned paths are pre-resolved so callers
+    can compare prefixes without per-call ``.resolve()``.
+
+    Memoised on a fingerprint of the inputs (Claude projects list,
+    cwd, FLOWPAD_DOC_DIRS) so a new Claude project or env-var change
+    transparently invalidates the cache without a manual hook.
     """
+    return _doc_search_dirs_cached(_doc_search_dirs_fingerprint())
+
+
+def _doc_search_dirs_fingerprint() -> tuple:
+    """Cheap snapshot of every input that affects ``_doc_search_dirs``.
+
+    One ``iterdir`` + a ``getcwd`` + an ``environ`` lookup — sub-millisecond
+    and orders of magnitude cheaper than the cached body.
+    """
+    try:
+        proj_dir = get_instance_settings().claude_projects_dir
+        projects = (
+            tuple(sorted(p.name for p in proj_dir.iterdir()))
+            if proj_dir.is_dir() else ()
+        )
+    except OSError:
+        projects = ()
+    return (os.getcwd(), os.environ.get("FLOWPAD_DOC_DIRS", ""), projects)
+
+
+@functools.lru_cache(maxsize=4)
+def _doc_search_dirs_cached(_fingerprint: tuple) -> tuple[Path, ...]:
     dirs: list[Path] = []
     seen: set[Path] = set()
 
     def _add(p: Path) -> None:
-        rp = p.resolve()
-        if rp not in seen and rp.is_dir():
-            seen.add(rp)
-            dirs.append(p)
+        try:
+            rp = p.resolve()
+        except OSError:
+            return
+        if rp in seen or not rp.is_dir():
+            return
+        seen.add(rp)
+        dirs.append(rp)
 
     _add(get_instance_settings().claude_docs_dir)
 
-    # SDK-shipped system docs under the Flowpad Assistant system project.
     try:
         from flow_sdk.config import flowpad_assistant_project_root
         _add(flowpad_assistant_project_root() / "docs")
@@ -100,7 +131,7 @@ def _doc_search_dirs() -> list[Path]:
         if extra.strip():
             _add(Path(extra.strip()))
 
-    return dirs
+    return tuple(dirs)
 
 
 _SYSTEM_PID_CACHE: dict[str, str | None] = {}
@@ -138,8 +169,8 @@ def _resolve_system_project_id_for_path(path: Path) -> str | None:
 def _resolve_vault_root(path: Path) -> str | None:
     """Return the canonical abs path of the scan root that owns `path`, if any.
 
-    Walks _doc_search_dirs() looking for the first root that is an ancestor of
-    `path.resolve()`. Resolved before comparison so symlinks agree.
+    Roots from ``_doc_search_dirs`` are pre-resolved, so symlink agreement
+    only requires resolving the target once.
     """
     try:
         target = path.resolve()
@@ -147,14 +178,10 @@ def _resolve_vault_root(path: Path) -> str | None:
         return None
     for root in _doc_search_dirs():
         try:
-            root_resolved = root.resolve()
-        except OSError:
-            continue
-        try:
-            target.relative_to(root_resolved)
+            target.relative_to(root)
         except ValueError:
             continue
-        return str(root_resolved)
+        return str(root)
     return None
 
 

--- a/ts_sdk/src/config/load_config.ts
+++ b/ts_sdk/src/config/load_config.ts
@@ -6,6 +6,7 @@ declare const __AUTH_PROVIDER__: string;
 declare const __DEPLOY_ENV__: string;
 declare const __FLOWPAD_APP_HOST__: string;
 declare const __FLOWPAD_APP_PORT__: string;
+declare const __FLOWPAD_DEV__: boolean;
 declare const __SENTRY_DSN__: string;
 declare const __SENTRY_PROJECT__: string;
 

--- a/ts_sdk/src/entities/shell.ts
+++ b/ts_sdk/src/entities/shell.ts
@@ -337,7 +337,15 @@ export class Shell extends APIEntity<Shell> implements IShell {
     if (this.status === ShellStatus.ERROR) return;
     if (!this._hasEverBeenActive) return;
     const workdir = this.workdir ?? dataContext.project?.fs_storage_mount_path ?? undefined;
-    void this.start({ cols: 80, rows: 24, workdir });
+    // Owned-shell guard: shells owned by an AgenticProcess have their
+    // recovery driven at the process layer (it knows session_id, --resume,
+    // env injection). Bare ``Shell.start`` would just spawn an empty PTY
+    // that the agentic-process open then has to drop. Lazy import keeps the
+    // existing module-dependency direction (agentic-process imports Shell).
+    void import('../process/agentic-process').then(({ _isShellOwnedByAgenticProcess }) => {
+      if (_isShellOwnedByAgenticProcess(this.id)) return;
+      void this.start({ cols: 80, rows: 24, workdir });
+    });
   }
 
   // ── Entity lifecycle ──────────────────────────────────────────────────────

--- a/ts_sdk/src/process/agentic-process.ts
+++ b/ts_sdk/src/process/agentic-process.ts
@@ -1158,6 +1158,18 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
   }
 
   /**
+   * Symlink a skill folder into this process's assets dir so Claude Code
+   * discovers it at startup. `sourcePath` is the absolute path of the skill
+   * folder (parent of SKILL.md). Live edits to the source SKILL.md flow
+   * through to the next chat — no re-materialization needed.
+   */
+  async loadEmbeddedSkill(sourcePath: string): Promise<void> {
+    const actionInfo = new ActionInfo('load-embedded-skill', AgenticProcess.type, this.id, 'POST');
+    actionInfo.bodyParameters = { asset_ref: sourcePath };
+    await dataManager.callAction(actionInfo);
+  }
+
+  /**
    * Unified read-side view of every asset visible to this process.
    * Mirrors `flow_sdk.builtin.agentic_process.AgenticProcess.get_asset_descriptors`.
    *

--- a/ts_sdk/src/process/agentic-process.ts
+++ b/ts_sdk/src/process/agentic-process.ts
@@ -59,6 +59,32 @@ export interface ProcessState {
 }
 
 /**
+ * OS-level status snapshot returned by the backend ``os-status`` action.
+ * Single source of truth for "is this process alive right now?". Combines
+ * persisted entity status, in-memory PTY-session state on the compute
+ * node, and a real PID liveness check (psutil + cmdline match).
+ *
+ * ``ready`` is the answer to ``AgenticProcess.isAlive()``: true iff the
+ * PTY session is alive AND the worker PID matches the recorded session.
+ */
+export interface AgenticProcessOSStatus {
+  process_id: string;
+  process_status: string;
+  shell_id: string | null;
+  shell_status: string | null;
+  session_id: string | null;
+  pty_pid: number | null;
+  worker_pid: number | null;
+  worker_name: string | null;
+  pty_alive: boolean;
+  worker_alive: boolean;
+  has_attachable_pty: boolean;
+  ready: boolean;
+  reason: string | null;
+  checked_at: string;
+}
+
+/**
  * Response from get-history action
  */
 interface HistoryResponse {
@@ -1550,6 +1576,29 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
       ptyId: result.pty_id,
     });
     return true;
+  }
+
+  /**
+   * Read-only OS-level status snapshot. Calls the backend ``os-status``
+   * action which checks the PTY session liveness on the compute node and
+   * the worker PID via psutil + cmdline match. Use this whenever you need
+   * ground truth about whether the process is actually running — never
+   * infer it from the cached ``status`` field.
+   */
+  async getOsStatus(): Promise<AgenticProcessOSStatus> {
+    const actionInfo = new ActionInfo('os-status', AgenticProcess.type, this.id, 'GET');
+    const result = await dataManager.callAction<unknown, AgenticProcessOSStatus>(actionInfo);
+    if (!result) throw new Error('os-status returned no data');
+    return result;
+  }
+
+  /**
+   * True iff the backend reports both an alive PTY session and a live
+   * worker PID for this process. Sugar over ``getOsStatus().ready``.
+   */
+  async isAlive(): Promise<boolean> {
+    const status = await this.getOsStatus();
+    return status.ready;
   }
 
   /**

--- a/ts_sdk/src/process/agentic-process.ts
+++ b/ts_sdk/src/process/agentic-process.ts
@@ -27,6 +27,47 @@ import { VFSPath } from '../utils/vfs-path';
 import { AgenticContext, IAgenticProcessOptions, ISpawnWorkerOptions, PermissionMode } from './agentic-context';
 import { ProcessIconKey, ProcessStatus, WorkerStatus, isWorkerRunning, isWorkerTerminal } from './agentic-types';
 
+// ---------------------------------------------------------------------------
+// Auto-recovery dispatcher — mirrors Shell's static-listener pattern at
+// ts_sdk/src/entities/shell.ts:81-95. A single ConnectionManager listener and
+// a periodic poll fan out to every registered AgenticProcess; each instance's
+// ``reconnect()`` then short-circuits cheaply when nothing is wrong, so the
+// fan-out cost is one ``GET /os-status`` per registered process per tick.
+// ---------------------------------------------------------------------------
+const _agenticProcessRegistry = new Set<AgenticProcess>();
+let _agenticListenersRegistered = false;
+let _pollTimer: ReturnType<typeof setInterval> | null = null;
+const _POLL_INTERVAL_MS = 5000;
+
+function _ensureAgenticStaticListeners(): void {
+  if (_agenticListenersRegistered) return;
+  _agenticListenersRegistered = true;
+  void import('../websocket').then(({ ConnectionManager }) => {
+    const cm = ConnectionManager.getInstance();
+    cm.on('on_reconnected', () => {
+      for (const proc of _agenticProcessRegistry) void proc.reconnect();
+    });
+  });
+  if (_pollTimer === null) {
+    _pollTimer = setInterval(() => {
+      for (const proc of _agenticProcessRegistry) void proc.reconnect();
+    }, _POLL_INTERVAL_MS);
+  }
+}
+
+/**
+ * Predicate consumed by ``Shell._onCmReconnected`` so the bare-shell
+ * reconnect handler skips shells that are owned by an AgenticProcess. The
+ * process layer drives recovery — it knows the session_id, --resume, env
+ * injection. Bare ``Shell.start()`` would just spawn an empty PTY.
+ */
+export function _isShellOwnedByAgenticProcess(shellId: string): boolean {
+  for (const proc of _agenticProcessRegistry) {
+    if (proc.shell_id === shellId) return true;
+  }
+  return false;
+}
+
 /**
  * Result returned by AgenticProcess.spawn().
  */
@@ -766,6 +807,14 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
   private _historyLoaded: boolean = false;
   private _historyLoading: Promise<void> | null = null;
 
+  /**
+   * True after the user explicitly stopped this process (``stop`` /
+   * ``exit`` / ``close``) and before the next successful ``start``. Gates
+   * the auto-recovery dispatcher so a deliberately stopped process is not
+   * silently relaunched.
+   */
+  private _userInitiatedStop: boolean = false;
+
   constructor(entity: Partial<IAgenticProcess> = {}) {
     super(entity);
     this.instruction_content = entity.instruction_content;
@@ -1448,6 +1497,11 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
   async exit(): Promise<void> {
     if (!this.shell_id) return; // Nothing to exit
 
+    // Mark this stop as user-initiated so the auto-recovery dispatcher does
+    // not relaunch the worker between the optimistic CLOSING update and the
+    // backend's eventual STOPPED/STOPPING write.
+    this._userInitiatedStop = true;
+
     // Optimistically mark the shell CLOSING synchronously (no await) so the
     // loader's resolveDefaultShell sees it as non-alive and won't redirect back
     // to this tab while the exit API call is in-flight.
@@ -1494,6 +1548,11 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
    */
   async close(): Promise<void> {
     if (this.status === ProcessStatus.STOPPING || this.status === ProcessStatus.STOPPED) return;
+
+    // Permanent teardown — deregister so neither the poll nor the
+    // on_reconnected dispatcher tries to relaunch this process.
+    this._userInitiatedStop = true;
+    _agenticProcessRegistry.delete(this);
 
     if (this.shell_id) {
       const shell = Shell.getByIdFromCache(this.shell_id);
@@ -1575,6 +1634,11 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
       timeout: options?.ptyTimeout,
       ptyId: result.pty_id,
     });
+    // Successful open clears any prior user-stop intent and registers this
+    // process for auto-recovery (poll + on_reconnected dispatcher).
+    this._userInitiatedStop = false;
+    _agenticProcessRegistry.add(this);
+    _ensureAgenticStaticListeners();
     return true;
   }
 
@@ -1599,6 +1663,34 @@ export class AgenticProcess extends APIEntity<AgenticProcess> implements IAgenti
   async isAlive(): Promise<boolean> {
     const status = await this.getOsStatus();
     return status.ready;
+  }
+
+  /**
+   * Auto-recovery entry point. Driven by the static reconnect dispatcher on
+   * ConnectionManager ``on_reconnected`` events and a 5 s poll. Cheap when
+   * the process is healthy: one GET ``os-status`` and an early return.
+   *
+   * Skipped when:
+   *   - user explicitly stopped this process (``_userInitiatedStop``);
+   *   - status is mid-transition (``STARTING`` / ``STOPPING``) — let the
+   *     in-flight call finish first;
+   *   - status is ``FAILED`` — relaunching would loop because the worker
+   *     can't start with the current ``cli_options``.
+   *
+   * Concurrent triggers (e.g. ``on_reconnected`` arriving while a poll is
+   * already in flight) converge: the backend's per-process ``_OPEN_LOCKS``
+   * mutex serializes ``open``, and the second ``isAlive()`` call sees the
+   * first recovery's result and short-circuits.
+   *
+   * @returns true iff a recovery ``start()`` was issued.
+   */
+  async reconnect(): Promise<boolean> {
+    if (this._userInitiatedStop) return false;
+    if (this.status === ProcessStatus.STARTING || this.status === ProcessStatus.STOPPING) return false;
+    if (this.status === ProcessStatus.FAILED) return false;
+    if (await this.isAlive()) return false;
+    await this.start({ visible: this.visible });
+    return true;
   }
 
   /**

--- a/ui/src/components/assets/editor/skill/SkillAssetEditor.tsx
+++ b/ui/src/components/assets/editor/skill/SkillAssetEditor.tsx
@@ -1,6 +1,8 @@
 import { MarkdownEditor } from '@src/components/assets/editor/markdown/MarkdownEditor';
+import { EntityChatPanel } from '@src/components/entity-chat-panel';
 import { useEntityByPath } from '@src/hooks/use-entity-by-path';
-import { FSRef, Skill } from '@sdk';
+import { AgenticProcess, FSRef, Skill } from '@sdk';
+import { useCallback } from 'react';
 
 interface SkillAssetEditorProps {
   /** FSRef to the skill folder. SKILL.md is resolved via child(). */
@@ -8,19 +10,38 @@ interface SkillAssetEditorProps {
 }
 
 /**
- * Thin wrapper around MarkdownEditor for skill assets.
- * Skills are folders; the content lives at <folder>/SKILL.md. Chat keys on
- * the folder-level Skill entity, not on SKILL.md itself.
+ * Skill assets render two chat surfaces, mirroring AgentAssetEditor:
+ *   - Side drawer "chat with the doc" — keyed on SKILL.md's vpath.
+ *   - Bottom "talk with the skill" — keyed on the skill entity's typeId;
+ *     first send symlinks the live skill folder under the process's
+ *     assets dir so Claude Code discovers it via --add-dir at startup.
  */
 export function SkillAssetEditor({ fsRef }: SkillAssetEditorProps) {
   const { entity: skill } = useEntityByPath<Skill>(Skill.type, fsRef);
-  // Prefer skill.doc (built from skill.asset_ref/SKILL.md) once entity loads;
-  // fall back to URL-derived fsRef.child('SKILL.md') while it's loading.
   const editorRef = skill?.doc ?? fsRef.child('SKILL.md');
+  const sourcePath = skill?.asset_ref ?? fsRef.path;
+  const embedSkill = useCallback(
+    async (proc: AgenticProcess) => {
+      await proc.loadEmbeddedSkill(sourcePath);
+    },
+    [sourcePath],
+  );
+  const docTarget = editorRef.vpath;
+  const skillTarget = skill ? skill.typeId.toString() : null;
   return (
-    <MarkdownEditor
-      fsRef={editorRef}
-      chatTarget={skill ? skill.typeId.toString() : null}
-    />
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1">
+        <MarkdownEditor fsRef={editorRef} chatTarget={docTarget} />
+      </div>
+      {skillTarget && (
+        <div className="h-[300px] flex-shrink-0 border-t" data-testid="skill-bottom-chat">
+          <EntityChatPanel
+            target={skillTarget}
+            onProcessCreated={embedSkill}
+            className="h-full"
+          />
+        </div>
+      )}
+    </div>
   );
 }

--- a/ui/src/components/terminal/HistoryModal.tsx
+++ b/ui/src/components/terminal/HistoryModal.tsx
@@ -4,7 +4,6 @@ import { useEntitiesQuery } from '@sdk/react/hooks';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@src/components/ui/dialog';
 import { ClaudeIcon } from '@src/components/icons/ClaudeIcon';
 import { useClaudeHistory } from '@src/hooks/useClaudeHistory';
-import { useContext } from '@src/hooks/useContext';
 import React, { useEffect, useMemo, useState } from 'react';
 
 const LIMIT = 10;
@@ -108,21 +107,8 @@ const processQuery = new QueryRequest({
   }),
 });
 
-function stripTrailingSlash(p: string): string {
-  return p.replace(/[/\\]+$/, '');
-}
-
 export function useRecentSessions(enabled: boolean = true): RecentItem[] {
-  const { project } = useContext();
-  const currentProjectId = project?.id ?? null;
-  const currentProjectPath = useMemo(
-    () => (project?.fs_storage_mount_path ? stripTrailingSlash(project.fs_storage_mount_path) : null),
-    [project?.fs_storage_mount_path],
-  );
-
-  // List 1: last N agentic_process entities. Query stays global; we filter
-  // client-side by project_id so the cache/subscription is shared with anyone
-  // else who needs the global list.
+  // List 1: last N agentic_process entities across all projects
   const { data: processes = [] } = useEntitiesQuery<AgenticProcess>(processQuery);
 
   // List 2: last N entries from ~/.claude/history.jsonl across all projects
@@ -130,21 +116,12 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
   // a GET discovery/claude_session + POST upsertSessionProcess.
   const { entries: historyEntries } = useClaudeHistory(HISTORY_FETCH, { enabled });
 
-  // Filter history entries by current project BEFORE the resolution loop —
-  // each unfiltered entry would trigger an AgenticProcess.fromClaudeSession
-  // round-trip. history.jsonl's `project` field is an absolute filesystem
-  // path, so compare against fs_storage_mount_path.
-  const filteredHistoryEntries = useMemo(() => {
-    if (!currentProjectPath) return historyEntries;
-    return historyEntries.filter((entry) => stripTrailingSlash(entry.project ?? '') === currentProjectPath);
-  }, [historyEntries, currentProjectPath]);
-
   const [historyItems, setHistoryItems] = useState<RecentItem[]>([]);
 
   // Per-session metadata harvested from history entries (ships `_session` with `include=claude_session`).
   const sessionMetaMap = useMemo(() => {
     const m = new Map<string, SessionMeta>();
-    for (const entry of filteredHistoryEntries) {
+    for (const entry of historyEntries) {
       if (!entry.session_id) continue;
       const fromSession = metaFromSession(entry._session);
       m.set(entry.session_id, {
@@ -153,17 +130,17 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
       });
     }
     return m;
-  }, [filteredHistoryEntries]);
+  }, [historyEntries]);
 
   useEffect(() => {
-    if (!enabled || filteredHistoryEntries.length === 0) {
+    if (!enabled || historyEntries.length === 0) {
       setHistoryItems([]);
       return;
     }
     let cancelled = false;
     void (async () => {
       const resolved: RecentItem[] = [];
-      for (const entry of filteredHistoryEntries) {
+      for (const entry of historyEntries) {
         if (!entry.session_id) continue;
         try {
           const p = await AgenticProcess.fromClaudeSession(entry.session_id);
@@ -186,12 +163,11 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
     return () => {
       cancelled = true;
     };
-  }, [enabled, filteredHistoryEntries, sessionMetaMap]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [enabled, historyEntries, sessionMetaMap]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return useMemo(() => {
     const processItems: RecentItem[] = processes
       .filter((p) => p.session_id != null)
-      .filter((p) => currentProjectId == null || p.project_id === currentProjectId)
       .map((p) => {
         const sid = p.session_id!;
         const meta = sessionMetaMap.get(sid) ?? {};
@@ -215,7 +191,7 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
         return true;
       })
       .slice(0, LIMIT);
-  }, [processes, historyItems, sessionMetaMap, currentProjectId]);
+  }, [processes, historyItems, sessionMetaMap]);
 }
 
 interface HistoryModalProps {

--- a/ui/src/components/terminal/HistoryModal.tsx
+++ b/ui/src/components/terminal/HistoryModal.tsx
@@ -4,6 +4,7 @@ import { useEntitiesQuery } from '@sdk/react/hooks';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@src/components/ui/dialog';
 import { ClaudeIcon } from '@src/components/icons/ClaudeIcon';
 import { useClaudeHistory } from '@src/hooks/useClaudeHistory';
+import { useContext } from '@src/hooks/useContext';
 import React, { useEffect, useMemo, useState } from 'react';
 
 const LIMIT = 10;
@@ -107,8 +108,21 @@ const processQuery = new QueryRequest({
   }),
 });
 
+function stripTrailingSlash(p: string): string {
+  return p.replace(/[/\\]+$/, '');
+}
+
 export function useRecentSessions(enabled: boolean = true): RecentItem[] {
-  // List 1: last N agentic_process entities across all projects
+  const { project } = useContext();
+  const currentProjectId = project?.id ?? null;
+  const currentProjectPath = useMemo(
+    () => (project?.fs_storage_mount_path ? stripTrailingSlash(project.fs_storage_mount_path) : null),
+    [project?.fs_storage_mount_path],
+  );
+
+  // List 1: last N agentic_process entities. Query stays global; we filter
+  // client-side by project_id so the cache/subscription is shared with anyone
+  // else who needs the global list.
   const { data: processes = [] } = useEntitiesQuery<AgenticProcess>(processQuery);
 
   // List 2: last N entries from ~/.claude/history.jsonl across all projects
@@ -116,12 +130,21 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
   // a GET discovery/claude_session + POST upsertSessionProcess.
   const { entries: historyEntries } = useClaudeHistory(HISTORY_FETCH, { enabled });
 
+  // Filter history entries by current project BEFORE the resolution loop —
+  // each unfiltered entry would trigger an AgenticProcess.fromClaudeSession
+  // round-trip. history.jsonl's `project` field is an absolute filesystem
+  // path, so compare against fs_storage_mount_path.
+  const filteredHistoryEntries = useMemo(() => {
+    if (!currentProjectPath) return historyEntries;
+    return historyEntries.filter((entry) => stripTrailingSlash(entry.project ?? '') === currentProjectPath);
+  }, [historyEntries, currentProjectPath]);
+
   const [historyItems, setHistoryItems] = useState<RecentItem[]>([]);
 
   // Per-session metadata harvested from history entries (ships `_session` with `include=claude_session`).
   const sessionMetaMap = useMemo(() => {
     const m = new Map<string, SessionMeta>();
-    for (const entry of historyEntries) {
+    for (const entry of filteredHistoryEntries) {
       if (!entry.session_id) continue;
       const fromSession = metaFromSession(entry._session);
       m.set(entry.session_id, {
@@ -130,17 +153,17 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
       });
     }
     return m;
-  }, [historyEntries]);
+  }, [filteredHistoryEntries]);
 
   useEffect(() => {
-    if (!enabled || historyEntries.length === 0) {
+    if (!enabled || filteredHistoryEntries.length === 0) {
       setHistoryItems([]);
       return;
     }
     let cancelled = false;
     void (async () => {
       const resolved: RecentItem[] = [];
-      for (const entry of historyEntries) {
+      for (const entry of filteredHistoryEntries) {
         if (!entry.session_id) continue;
         try {
           const p = await AgenticProcess.fromClaudeSession(entry.session_id);
@@ -163,11 +186,12 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
     return () => {
       cancelled = true;
     };
-  }, [enabled, historyEntries, sessionMetaMap]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [enabled, filteredHistoryEntries, sessionMetaMap]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return useMemo(() => {
     const processItems: RecentItem[] = processes
       .filter((p) => p.session_id != null)
+      .filter((p) => currentProjectId == null || p.project_id === currentProjectId)
       .map((p) => {
         const sid = p.session_id!;
         const meta = sessionMetaMap.get(sid) ?? {};
@@ -191,7 +215,7 @@ export function useRecentSessions(enabled: boolean = true): RecentItem[] {
         return true;
       })
       .slice(0, LIMIT);
-  }, [processes, historyItems, sessionMetaMap]);
+  }, [processes, historyItems, sessionMetaMap, currentProjectId]);
 }
 
 interface HistoryModalProps {

--- a/ui/src/components/terminal/TabbedTerminal.tsx
+++ b/ui/src/components/terminal/TabbedTerminal.tsx
@@ -165,9 +165,16 @@ const TabbedTerminal: React.FC<TabbedTerminalProps> = ({
   onTabClose,
   onTabOpen,
 }) => {
-  const { tabs: sessions } = useActiveTerminals({ collaborationRoomId });
   const { flow } = useAgentContext();
-  const { activeShellId: contextShellId, agenticProcess: contextAgenticProcess } = useContext();
+  const {
+    activeShellId: contextShellId,
+    agenticProcess: contextAgenticProcess,
+    project: contextProject,
+  } = useContext();
+  // Scope the tab strip to the current project (or the spawn project, when this
+  // strip is rendered for a CollaborationSpace that pins to a different project).
+  const tabsProjectId = spawnProjectId ?? contextProject?.id ?? null;
+  const { tabs: sessions } = useActiveTerminals({ collaborationRoomId, projectId: tabsProjectId });
   const _perfLoggedRef = useRef(false);
   if (!_perfLoggedRef.current) {
     _perfLoggedRef.current = true;

--- a/ui/src/components/terminal/interactive-terminal/TerminalBottomRibbon.tsx
+++ b/ui/src/components/terminal/interactive-terminal/TerminalBottomRibbon.tsx
@@ -3,7 +3,6 @@ import { Button } from '@src/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@src/components/ui/tooltip';
 import { cn } from '@src/lib/utils';
 import { FileText } from 'lucide-react';
-import { QueueButton } from './QueueButton';
 import type { QueueEntry, QueueState } from '@src/hooks/useAgenticQueue';
 import { SIDE_TABS, SideTabId, type SideTabId as SideTabIdType } from './side-windows';
 
@@ -21,32 +20,9 @@ interface TerminalBottomRibbonProps {
   onOpenLastPlan?: () => void;
 }
 
-const QueueNextLabel: React.FC<{ queue: QueueState }> = ({ queue }) => {
-  const next = (queue.entries ?? [])[0];
-  const text = next?.queue_entry_data.prompt ?? '';
-  const isEmpty = !text;
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="max-w-[160px] cursor-default truncate text-[11px] text-muted-foreground/70 select-none">
-          {isEmpty ? 'No pending prompts' : text}
-        </span>
-      </TooltipTrigger>
-      {!isEmpty && (
-        <TooltipContent side="top" className="max-w-xs whitespace-pre-wrap break-words">
-          {text}
-        </TooltipContent>
-      )}
-    </Tooltip>
-  );
-};
-
 const RIBBON_TABS: SideTabIdType[] = [
-  SideTabId.Shell,
   SideTabId.Git,
   SideTabId.Prompts,
-  SideTabId.Queue,
   SideTabId.Files,
 ];
 
@@ -70,17 +46,6 @@ export const TerminalBottomRibbon: React.FC<TerminalBottomRibbonProps> = ({
         <span
           className={`inline-flex h-2 w-2 rounded-full ${isActive ? 'bg-emerald-500' : 'bg-red-500'}`}
         />
-        {queue && onQueueAdd && onQueueRemove && (
-          <TooltipProvider delayDuration={400}>
-            <QueueButton
-              queue={queue}
-              onAdd={onQueueAdd}
-              onRemove={onQueueRemove}
-              onOpenPanel={() => onOpenSideTab(SideTabId.Queue)}
-            />
-            <QueueNextLabel queue={queue} />
-          </TooltipProvider>
-        )}
         {hasLastPlan && onOpenLastPlan && (
           <TooltipProvider delayDuration={400}>
             <Tooltip>

--- a/ui/src/contexts/dev-mode-context.tsx
+++ b/ui/src/contexts/dev-mode-context.tsx
@@ -10,7 +10,7 @@ declare global {
 
 const DEV_MODE_KEY = 'devMode';
 
-let _devMode: boolean = localStorage.getItem(DEV_MODE_KEY) === 'true' || import.meta.env.VITE_DEV_MODE === 'true';
+let _devMode: boolean = localStorage.getItem(DEV_MODE_KEY) === 'true' || __FLOWPAD_DEV__;
 const _listeners = new Set<(val: boolean) => void>();
 
 function setDevMode(val: boolean): void {

--- a/ui/src/hooks/useActiveTerminals.ts
+++ b/ui/src/hooks/useActiveTerminals.ts
@@ -28,6 +28,11 @@ export interface TabFilter {
   visible?: boolean;
   /** When set, only include shells tagged with this collaboration room id. */
   collaborationRoomId?: string | null;
+  /**
+   * When set, only include tabs whose Shell or linked AgenticProcess has
+   * this project_id. Tabs with no project association are dropped.
+   */
+  projectId?: string | null;
 }
 
 /**
@@ -40,12 +45,17 @@ export function filterTabs(
   processes: AgenticProcess[],
   filter: TabFilter = {},
 ): TerminalTab[] {
-  const { visible = false, collaborationRoomId = null } = filter;
+  const { visible = false, collaborationRoomId = null, projectId = null } = filter;
   const activeProcesses = processes.filter((p) => isProcessActive(p.status));
 
   const sidecarShellIds = new Set<string>();
   for (const proc of processes) {
     if (proc.sidecar_shell_id) sidecarShellIds.add(proc.sidecar_shell_id);
+  }
+
+  const shellToProcess = new Map<string, AgenticProcess>();
+  for (const proc of activeProcesses) {
+    if (proc.shell_id) shellToProcess.set(proc.shell_id, proc);
   }
 
   const keptShells = shells.filter((shell) => {
@@ -56,13 +66,13 @@ export function filterTabs(
     if (collaborationRoomId != null && shell.collaboration_room_id !== collaborationRoomId) {
       return false;
     }
+    if (projectId != null) {
+      const linked = shellToProcess.get(shell.id);
+      const tabProjectId = shell.project_id ?? linked?.project_id ?? null;
+      if (tabProjectId !== projectId) return false;
+    }
     return true;
   });
-
-  const shellToProcess = new Map<string, AgenticProcess>();
-  for (const proc of activeProcesses) {
-    if (proc.shell_id) shellToProcess.set(proc.shell_id, proc);
-  }
 
   const result: TerminalTab[] = keptShells.map((shell) => {
     const linkedProcess = shellToProcess.get(shell.id);
@@ -112,18 +122,20 @@ const processQuery = new QueryRequest({
  */
 export interface UseActiveTerminalsOptions {
   collaborationRoomId?: string | null;
+  /** When set, only return tabs whose shell/process belongs to this project_id. */
+  projectId?: string | null;
 }
 
 export function useActiveTerminals(options: UseActiveTerminalsOptions = {}) {
-  const { collaborationRoomId = null } = options;
+  const { collaborationRoomId = null, projectId = null } = options;
   const { data: shells = [], isLoading: shellsLoading } = useEntitiesQuery<Shell>(shellQuery);
   const { data: processes = [], isLoading: processesLoading } =
     useEntitiesQuery<AgenticProcess>(processQuery);
   const shellProjectionKey = shells
-    .map((shell) => `${shell.id}:${shell.status ?? ''}:${shell.error_message ?? ''}:${shell.name ?? ''}:${shell.tab_order ?? 0}:${shell.collaboration_room_id ?? ''}`)
+    .map((shell) => `${shell.id}:${shell.status ?? ''}:${shell.error_message ?? ''}:${shell.name ?? ''}:${shell.tab_order ?? 0}:${shell.collaboration_room_id ?? ''}:${shell.project_id ?? ''}`)
     .join('|');
   const processProjectionKey = processes
-    .map((process) => `${process.id}:${process.status ?? ''}:${process.shell_id ?? ''}:${process.sidecar_shell_id ?? ''}`)
+    .map((process) => `${process.id}:${process.status ?? ''}:${process.shell_id ?? ''}:${process.sidecar_shell_id ?? ''}:${process.project_id ?? ''}`)
     .join('|');
 
   // Refs keep the latest arrays accessible without adding them as useMemo deps.
@@ -140,9 +152,10 @@ export function useActiveTerminals(options: UseActiveTerminalsOptions = {}) {
     return filterTabs(shellsRef.current, processesRef.current, {
       visible: true,
       collaborationRoomId,
+      projectId,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shellProjectionKey, processProjectionKey, collaborationRoomId]);
+  }, [shellProjectionKey, processProjectionKey, collaborationRoomId, projectId]);
 
   const isLoading = shellsLoading || processesLoading;
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => {
       __AUTH_PROVIDER__: JSON.stringify(env.AUTH_PROVIDER || 'local'),
       __DEPLOY_ENV__: JSON.stringify(env.DEPLOY_ENV || 'local'),
       __IS_PACKAGE__: JSON.stringify(!!isPackage),
+      __FLOWPAD_DEV__: JSON.stringify(env.FLOWPAD_DEV === 'true'),
     },
     build: {
       sourcemap: true,


### PR DESCRIPTION
## Summary

4 commits on `v0.2.19-fixes`:

- **Skill bottom chat + load-embedded-skill action** (`7c10893`): SkillAssetEditor now mirrors AgentAssetEditor's two-chat layout — side drawer keyed on SKILL.md vpath, bottom panel keyed on the skill entity's typeId. First send symlinks the live skill folder under the process's assets dir so Claude Code discovers it via `--add-dir`. New `_doc_search_dirs_cached` memoises markdown doc roots on a cheap fingerprint.

- **`AgenticProcess.os-status` + HistoryModal + `__FLOWPAD_DEV__` build define** (`fbe8e51`): single-source-of-truth liveness snapshot (persisted status + PTY-session liveness + real PID check); `ready` headline drives `AgenticProcess.isAlive()`. HistoryModal/TerminalBottomRibbon refactored. Vite-define `__FLOWPAD_DEV__` replaces `import.meta.env.VITE_DEV_MODE`.

- **Project-scoped tab strip** (`0c1e97d`): `useActiveTerminals` filters by current/spawn project so the tab strip only surfaces matching processes; HistoryModal stays global on purpose ("jump to anywhere").

- **Auto-recovery dispatcher + Shell owned-shell guard** (`c81f317`): single static dispatcher for AgenticProcess (`on_reconnected` + 5s poll fan-out). `_userInitiatedStop` flag gates the dispatcher so a deliberately stopped process isn't silently relaunched. Shell reconnect now skips shells owned by an AgenticProcess via `_isShellOwnedByAgenticProcess(id)` — process layer knows `session_id`/`--resume`/env injection; bare `Shell.start()` would just spawn an empty PTY.

## Test plan

- [ ] Open a Skill asset; click the bottom chat panel and confirm the skill folder is symlinked under `<process>/assets/.claude/skills/<name>/` and Claude sees it
- [ ] Disconnect the WS; confirm AgenticProcess auto-reconnects within 5s without spawning duplicate PTYs
- [ ] Stop a process via the toolbar; confirm the dispatcher does NOT relaunch it
- [ ] Switch projects; confirm the tab strip in TabbedTerminal only shows the current project's processes
- [ ] `uv run pytest tests/unit/test_agentic_process_get_assets.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)