### PR TITLE
FLOWPAD-1852: align scenario B delivery with A/C bundle path; rename post_login → login_callback

### DIFF
--- a/flow_sdk/app/actions/flow_message_action.py
+++ b/flow_sdk/app/actions/flow_message_action.py
@@ -1043,7 +1043,21 @@ async def handle_conversation_sync(someone_typeid: str) -> ApiResponse:
                     m_created = m.get("created_date") or ""
                     if m_created and m_created <= last_sync:
                         continue
-                    if await _materialize_remote_flow_message(m, conv.id, someone_typeid):
+                    fm_id = (m.get("id") or "").strip()
+                    attachment_filename = (m.get("attachment_filename") or "").strip()
+                    materialized = False
+                    if fm_id and attachment_filename:
+                        # Bundle delivery: download + unpack writes the FM,
+                        # appends the conversation pointer, and lands all
+                        # FILE/PROMPT blobs in entity storage atomically —
+                        # same path task-bound replies use.
+                        materialized = await _download_and_unpack_bundle(fm_id, attachment_filename)
+                    if not materialized:
+                        # No bundle on hub (text-only message or upload failed):
+                        # fall back to metadata-only mirror so the message still
+                        # surfaces in the conversation.
+                        materialized = bool(await _materialize_remote_flow_message(m, conv.id, someone_typeid))
+                    if materialized:
                         fm_count += 1
                     if m_created and m_created > new_high_water:
                         new_high_water = m_created

--- a/flow_sdk/app/actions/flow_message_action.py
+++ b/flow_sdk/app/actions/flow_message_action.py
@@ -666,8 +666,9 @@ async def handle_send_draft(fm_id: str, someone_typeid: str) -> ApiResponse:
         return ApiFailResponse(message=f"Conversation not found: {fm.conversation_id}")
 
     task: Optional[Task] = None
-    if conv.task_id:
-        task = await Task.get_one({"id": conv.task_id})
+    task_typeid = conv.first_context_of_type(BuiltinEntityType.TASK.value)
+    if task_typeid:
+        task = await Task.get_one({"id": task_typeid.id})
 
     conv = await _append_message_to_conversation(
         conv=conv,

--- a/flow_sdk/app/actions/notification_action.py
+++ b/flow_sdk/app/actions/notification_action.py
@@ -897,7 +897,7 @@ async def _read_upload_files(uploads: list) -> dict[str, bytes]:
     return out
 
 
-async def _handle_hub_mirrored_append(
+async def _handle_plain_conversation_append(
     *,
     conv: Conversation,
     message: str,
@@ -908,15 +908,22 @@ async def _handle_hub_mirrored_append(
     prompt_files: list,
     someone_typeid: str,
 ) -> ApiResponse:
-    """Hub-mirrored send path: hub allocates the FM id, both sides mirror.
+    """Send path for plain (taskless) replies on a hub-mirrored conversation.
 
-    The local-first append-conversation path doesn't fit hub-mirrored conversations
-    because the hub's ``add_message`` action treats a body-supplied ``id`` as a
-    reference to an existing entity (and 404s when not found). So we do the
-    inverse: push first, materialize locally with the hub-allocated id.
+    Identical bundle delivery to the task-bound path; the only divergence is
+    *id allocation*. The hub's ``conversation/{id}/add_message`` action
+    requires hub-allocated ids (it 404s on body-supplied ones), so we POST
+    first, then build the local FM with the returned id, then pack and
+    upload the .flowmsg bundle. ``context_entities`` carries the Conversation
+    TypeId so receiver-side ``unpack_bundle`` can resolve target_conv_id and
+    thread the message through the conversation pointer; ``_upload_bundle_to_hub``
+    stamps ``attachment_filename`` on the hub FM, which is the signal
+    ``handle_conversation_sync`` uses to switch from metadata-only mirror
+    to bundle download on the receiver.
     """
-    from flow_sdk.app.actions.flow_message_action import _materialize_remote_flow_message
+    from flow_sdk.app.actions.materialize_flow_message import materialize_flow_message
     from flow_sdk.builtin.flow_message import AttachmentType
+    from flow_sdk.fs_store.type_id import TypeId
     from flow_sdk.storage import get_entity_embedded_storage
 
     if not hub_base_url():
@@ -947,36 +954,33 @@ async def _handle_hub_mirrored_append(
         return ApiFailResponse(message="Hub returned no flow_message id")
     fm_id = hub_fm["id"]
 
-    # Hub upload path: sub_path is the *destination directory*; the hub's
-    # upload action appends the multipart filename. So `upload/data` +
-    # filename `foo.png` lands at `data/foo.png` (NOT `data/foo.png/foo.png`).
-    logger.warning(
-        "[hub_mirrored_append] uploading to hub fm=%s files=%s prompt_files=%s",
-        fm_id, list(file_bytes.keys()), list(prompt_file_bytes.keys()),
+    # Materialize the local FM with the hub-allocated id. context_entities
+    # carries the Conversation TypeId so pack_bundle's header.json contains
+    # the pointer the receiver's unpack_bundle uses to thread the message
+    # through materialize_flow_message → conversation.jsonl.
+    local_payload = {
+        "id": fm_id,
+        "text": message,
+        "sender_id": sender_id,
+        "sender_name": sender_name,
+        "context_entities": [str(TypeId(type=BuiltinEntityType.CONVERSATION.value, id=conv.id))],
+        "attachment": attachment,
+        "conversation_id": conv.id,
+        "remote": True,
+    }
+    if hub_fm.get("created_date"):
+        local_payload["created_date"] = hub_fm["created_date"]
+    fm = await materialize_flow_message(
+        local_payload,
+        conversation_id=conv.id,
+        someone_typeid=someone_typeid,
+        bundle_ts=hub_fm.get("created_date"),
     )
-    for name, data in file_bytes.items():
-        try:
-            await hub_post(
-                BuiltinEntityType.FLOW_MESSAGE, {}, fm_id, "fs", "upload/data",
-                files={"uploaded_file": (name, data, "application/octet-stream")},
-            )
-            logger.warning("[hub_mirrored_append] uploaded data/%s (%d bytes)", name, len(data))
-        except HubError as e:
-            logger.warning("[hub_mirrored_append] file upload %s failed: %s", name, e)
-    for name, data in prompt_file_bytes.items():
-        try:
-            await hub_post(
-                BuiltinEntityType.FLOW_MESSAGE, {}, fm_id, "fs", "upload/prompt",
-                files={"uploaded_file": (name, data, "application/octet-stream")},
-            )
-            logger.warning("[hub_mirrored_append] uploaded prompt/%s (%d bytes)", name, len(data))
-        except HubError as e:
-            logger.warning("[hub_mirrored_append] prompt file upload %s failed: %s", name, e)
 
-    fm = await _materialize_remote_flow_message(hub_fm, conv.id, someone_typeid)
-    if not fm:
-        return ApiFailResponse(message="Failed to materialize FlowMessage locally")
-
+    # Write blobs to sender's local entity storage so pack_bundle can read
+    # them. Layout (data/<name>, prompt/<name>) matches what the receiver's
+    # _rewrite_file_attachments writes after unpack — sender and receiver
+    # resolve fs/download identically.
     storage = get_entity_embedded_storage(fm.typeid)
     for name, data in file_bytes.items():
         path = Path(storage.get_storage_path(f"data/{name}"))
@@ -986,6 +990,12 @@ async def _handle_hub_mirrored_append(
         path = Path(storage.get_storage_path(f"prompt/{name}"))
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
+
+    # Pack the .flowmsg bundle and upload to the hub. _upload_bundle_to_hub
+    # also stamps attachment_filename on the hub FM record — that's the
+    # signal handle_conversation_sync uses on the receiver to switch from
+    # metadata-only mirror to bundle download.
+    await _upload_bundle_to_hub(fm_id, fm, conv.title or "message")
 
     conv = await Conversation.get_one({"id": conv.id})
     return ApiSuccessResponse(data={
@@ -1096,11 +1106,12 @@ async def handle_append_conversation(body: dict, someone_typeid: str) -> ApiResp
     if not isinstance(prompt_files, list):
         prompt_files = [prompt_files]
 
-    # Hub-mirrored conversations require the hub to allocate the FM id —
-    # its add_message action 404s on body-supplied ids — so this path
-    # diverges from the local-first sequence.
+    # Plain (taskless) replies on a hub-mirrored conversation diverge only
+    # in id allocation: the hub's add_message action 404s on body-supplied
+    # ids, so we POST first and let the hub allocate. Bundle delivery from
+    # there on is identical to the task-bound path.
     if not task and conv.remote and not is_draft:
-        return await _handle_hub_mirrored_append(
+        return await _handle_plain_conversation_append(
             conv=conv,
             message=message,
             sender_id=sender_id,

--- a/flow_sdk/app/actions/notification_action.py
+++ b/flow_sdk/app/actions/notification_action.py
@@ -922,7 +922,7 @@ async def _handle_plain_conversation_append(
     to bundle download on the receiver.
     """
     from flow_sdk.app.actions.materialize_flow_message import materialize_flow_message
-    from flow_sdk.builtin.flow_message import AttachmentType
+    from flow_sdk.builtin.flow_message import AttachmentType, FILE_VFS_PREFIX, PROMPT_FILE_VFS_PREFIX
     from flow_sdk.fs_store.type_id import TypeId
     from flow_sdk.storage import get_entity_embedded_storage
 
@@ -936,9 +936,9 @@ async def _handle_plain_conversation_append(
     if prompt_text:
         attachment.append({"attachment_type": AttachmentType.PROMPT.value, "data": prompt_text, "proposer_id": sender_id})
     for name in prompt_file_bytes:
-        attachment.append({"attachment_type": AttachmentType.PROMPT.value, "data": f"prompt/{name}", "proposer_id": sender_id})
+        attachment.append({"attachment_type": AttachmentType.PROMPT.value, "data": f"{PROMPT_FILE_VFS_PREFIX}{name}", "proposer_id": sender_id})
     for name in file_bytes:
-        attachment.append({"attachment_type": AttachmentType.FILE.value, "data": f"data/{name}"})
+        attachment.append({"attachment_type": AttachmentType.FILE.value, "data": f"{FILE_VFS_PREFIX}{name}"})
 
     payload = {
         "text": message,
@@ -983,11 +983,11 @@ async def _handle_plain_conversation_append(
     # resolve fs/download identically.
     storage = get_entity_embedded_storage(fm.typeid)
     for name, data in file_bytes.items():
-        path = Path(storage.get_storage_path(f"data/{name}"))
+        path = Path(storage.get_storage_path(f"{FILE_VFS_PREFIX}{name}"))
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
     for name, data in prompt_file_bytes.items():
-        path = Path(storage.get_storage_path(f"prompt/{name}"))
+        path = Path(storage.get_storage_path(f"{PROMPT_FILE_VFS_PREFIX}{name}"))
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
 

--- a/flow_sdk/app/actions/notification_action.py
+++ b/flow_sdk/app/actions/notification_action.py
@@ -481,20 +481,61 @@ async def _send_hub_notification(
     return hub_flow_message_id, email_error
 
 
-async def _upload_bundle_to_hub(hub_flow_message_id: str, fm: "FlowMessage", task_title: str) -> None:
-    """Pack and upload the .flowmsg bundle to the hub (best-effort, non-fatal)."""
+def _bundle_filename_for(task_title: str) -> str:
+    """Deterministic .flowmsg filename for a given title — callable before the
+    FM exists so callers can pre-stamp ``attachment_filename`` on the hub FM at
+    creation time (avoids a follow-up PUT, which 'member'-role senders can't make).
+    """
+    return f"{_meaningful_name(task_title)}.flowmsg"
+
+
+async def _pack_and_upload_bundle(
+    hub_flow_message_id: str, fm: "FlowMessage", bundle_filename: str,
+) -> bool:
+    """Pack the FM into a .flowmsg zip and POST it to the hub's fs/upload action.
+
+    Best-effort: returns True on success, False (with a warning) on any failure.
+    Caller is responsible for ensuring ``attachment_filename`` lands on the hub
+    FM record — either via this function's companion ``_upload_bundle_to_hub``
+    (PUT-based) or by including the field in the FM's create-time payload.
+    """
     try:
         zip_path = await fm.to_file()
-        bundle_filename = f"{_meaningful_name(task_title)}.flowmsg"
         content = zip_path.read_bytes()
         await hub_post(
             BuiltinEntityType.FLOW_MESSAGE, {}, hub_flow_message_id, "fs", "upload",
             files={"uploaded_file": (bundle_filename, content, "application/zip")},
         )
         zip_path.unlink(missing_ok=True)
-        await hub_put(BuiltinEntityType.FLOW_MESSAGE, hub_flow_message_id, {"attachment_filename": bundle_filename})
+        return True
     except Exception as _upload_err:
         logger.warning("[notification_action] bundle upload to hub failed (non-fatal): %s", _upload_err)
+        return False
+
+
+async def _upload_bundle_to_hub(hub_flow_message_id: str, fm: "FlowMessage", task_title: str) -> None:
+    """Pack, upload, and stamp ``attachment_filename`` on the hub FM via PUT.
+
+    Used by the task-bound reply path where the sender owns the FM and the
+    follow-up PUT is permitted. The plain-conversation path can't use this
+    (members lack PUT access on flow_message); it pre-stamps
+    ``attachment_filename`` via the ``add_message`` body and calls
+    ``_pack_and_upload_bundle`` directly.
+    """
+    bundle_filename = _bundle_filename_for(task_title)
+    if not await _pack_and_upload_bundle(hub_flow_message_id, fm, bundle_filename):
+        return
+    try:
+        await hub_put(
+            BuiltinEntityType.FLOW_MESSAGE,
+            hub_flow_message_id,
+            {"attachment_filename": bundle_filename},
+        )
+    except Exception as _put_err:
+        logger.warning(
+            "[notification_action] bundle attachment_filename PUT failed (non-fatal): %s",
+            _put_err,
+        )
 
 
 async def _save_local_notification(
@@ -910,16 +951,23 @@ async def _handle_plain_conversation_append(
 ) -> ApiResponse:
     """Send path for plain (taskless) replies on a hub-mirrored conversation.
 
-    Identical bundle delivery to the task-bound path; the only divergence is
-    *id allocation*. The hub's ``conversation/{id}/add_message`` action
-    requires hub-allocated ids (it 404s on body-supplied ones), so we POST
-    first, then build the local FM with the returned id, then pack and
-    upload the .flowmsg bundle. ``context_entities`` carries the Conversation
-    TypeId so receiver-side ``unpack_bundle`` can resolve target_conv_id and
-    thread the message through the conversation pointer; ``_upload_bundle_to_hub``
-    stamps ``attachment_filename`` on the hub FM, which is the signal
-    ``handle_conversation_sync`` uses to switch from metadata-only mirror
-    to bundle download on the receiver.
+    Identical bundle delivery to the task-bound path with two differences:
+
+    1. *Id allocation*: the hub's ``conversation/{id}/add_message`` action
+       requires hub-allocated ids (it 404s on body-supplied ones), so we POST
+       first, then build the local FM with the returned id.
+    2. *attachment_filename stamping*: the bundle filename is pre-computed
+       from ``conv.name`` and included in the ``add_message`` body so it
+       lands on the hub FM at creation time. The task-bound path PUTs it
+       afterwards via ``_upload_bundle_to_hub`` — but that PUT is rejected
+       for the 'member' role on someone else's conversation, so we sidestep
+       it here by pre-stamping.
+
+    ``context_entities`` carries the Conversation TypeId so receiver-side
+    ``unpack_bundle`` can resolve target_conv_id and thread the message
+    through the conversation pointer. ``attachment_filename`` is the signal
+    ``handle_conversation_sync`` uses on the receiver to switch from
+    metadata-only mirror to bundle download.
     """
     from flow_sdk.app.actions.materialize_flow_message import materialize_flow_message
     from flow_sdk.builtin.flow_message import AttachmentType, FILE_VFS_PREFIX, PROMPT_FILE_VFS_PREFIX
@@ -940,11 +988,20 @@ async def _handle_plain_conversation_append(
     for name in file_bytes:
         attachment.append({"attachment_type": AttachmentType.FILE.value, "data": f"{FILE_VFS_PREFIX}{name}"})
 
+    # Pre-compute the bundle filename so we can stamp it on the hub FM at
+    # creation time. This avoids a follow-up PUT to set attachment_filename,
+    # which a 'member'-role sender lacks permission to make on someone else's
+    # conversation. The filename is deterministic from conv.name, so it's
+    # safe to commit to it before the bundle exists.
+    bundle_title = conv.name or "message"
+    bundle_filename = _bundle_filename_for(bundle_title)
+
     payload = {
         "text": message,
         "sender_id": sender_id,
         "sender_name": sender_name,
         "attachment": attachment,
+        "attachment_filename": bundle_filename,
     }
     try:
         hub_fm = await hub_post(BuiltinEntityType.CONVERSATION, payload, conv.id, "add_message")
@@ -991,11 +1048,10 @@ async def _handle_plain_conversation_append(
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
 
-    # Pack the .flowmsg bundle and upload to the hub. _upload_bundle_to_hub
-    # also stamps attachment_filename on the hub FM record — that's the
-    # signal handle_conversation_sync uses on the receiver to switch from
-    # metadata-only mirror to bundle download.
-    await _upload_bundle_to_hub(fm_id, fm, conv.name or "message")
+    # Pack and upload the .flowmsg. attachment_filename was already stamped
+    # at creation time via the add_message payload, so no follow-up PUT is
+    # needed (which 'member' senders can't make anyway).
+    await _pack_and_upload_bundle(fm_id, fm, bundle_filename)
 
     conv = await Conversation.get_one({"id": conv.id})
     return ApiSuccessResponse(data={

--- a/flow_sdk/app/actions/notification_action.py
+++ b/flow_sdk/app/actions/notification_action.py
@@ -785,7 +785,7 @@ async def _attach_prompt(
     `prompt_files` is written to the entity VFS at `prompt/{filename}` and
     appended as a separate PROMPT attachment whose `data` is that VFS subpath.
     """
-    from flow_sdk.builtin.flow_message import Attachment, AttachmentType
+    from flow_sdk.builtin.flow_message import Attachment, AttachmentType, PROMPT_FILE_VFS_PREFIX
     from flow_sdk.storage import get_entity_embedded_storage
 
     new_atts: list = list(reply_fm.attachment or [])
@@ -801,7 +801,7 @@ async def _attach_prompt(
             if not hasattr(uf, "read"):
                 continue
             filename = getattr(uf, "filename", None) or "prompt.txt"
-            vfs_subpath = f"prompt/{filename}"
+            vfs_subpath = f"{PROMPT_FILE_VFS_PREFIX}{filename}"
             local_path = Path(storage.get_storage_path(vfs_subpath))
             local_path.parent.mkdir(parents=True, exist_ok=True)
             local_path.write_bytes(await uf.read())
@@ -819,7 +819,7 @@ async def _attach_uploaded_files(reply_fm: "FlowMessage", uploaded_files: list) 
     Files are stored at data/{filename} within the entity's embedded storage root so they can
     be served via GET /api/v1/graph/flow_message/{id}/fs/download/data/{filename}.
     """
-    from flow_sdk.builtin.flow_message import Attachment, AttachmentType
+    from flow_sdk.builtin.flow_message import Attachment, AttachmentType, FILE_VFS_PREFIX
     from flow_sdk.storage import get_entity_embedded_storage
 
     fm_typeid = reply_fm.typeid
@@ -830,7 +830,7 @@ async def _attach_uploaded_files(reply_fm: "FlowMessage", uploaded_files: list) 
         if not hasattr(uf, "read"):
             continue
         filename = getattr(uf, "filename", None) or "file"
-        vfs_subpath = f"data/{filename}"
+        vfs_subpath = f"{FILE_VFS_PREFIX}{filename}"
         local_path = Path(storage.get_storage_path(vfs_subpath))
         local_path.parent.mkdir(parents=True, exist_ok=True)
         content = await uf.read()
@@ -995,7 +995,7 @@ async def _handle_plain_conversation_append(
     # also stamps attachment_filename on the hub FM record — that's the
     # signal handle_conversation_sync uses on the receiver to switch from
     # metadata-only mirror to bundle download.
-    await _upload_bundle_to_hub(fm_id, fm, conv.title or "message")
+    await _upload_bundle_to_hub(fm_id, fm, conv.name or "message")
 
     conv = await Conversation.get_one({"id": conv.id})
     return ApiSuccessResponse(data={

--- a/flow_sdk/app/actions/oauth_action.py
+++ b/flow_sdk/app/actions/oauth_action.py
@@ -198,7 +198,7 @@ async def _get_flowpad_cloud_oauth_auth() -> ApiResponse:
     from flow_sdk.instance_settings import get_instance_settings
 
     public_url = os.environ.get("FLOWPAD_DOCKER_PUBLIC_URL", "").strip()
-    callback_path = "/api/v1/cloud/post_login"
+    callback_path = "/auth/login_callback"
     if public_url:
         callback_url = f"{public_url}{callback_path}"
     else:

--- a/flow_sdk/app/actions/task_action.py
+++ b/flow_sdk/app/actions/task_action.py
@@ -35,21 +35,24 @@ def _scope_from_task(task: Task, project_id: Optional[str]) -> HeadlessRunScope:
     project mapping happens after spawn. The draft context drops project
     (FlowMessage attachments don't reference projects today).
     """
+    conv_typeid = task.first_context_of_type(BuiltinEntityType.CONVERSATION.value)
+    spec_typeid = task.first_context_of_type(BuiltinEntityType.SPEC.value)
+
     process_ctx: list[TypeId] = [TypeId(type=BuiltinEntityType.TASK.value, id=task.id)]
-    if task.conversation_id:
-        process_ctx.append(TypeId(type=BuiltinEntityType.CONVERSATION.value, id=task.conversation_id))
-    if task.spec_id:
-        process_ctx.append(TypeId(type=BuiltinEntityType.SPEC.value, id=task.spec_id))
+    if conv_typeid:
+        process_ctx.append(conv_typeid)
+    if spec_typeid:
+        process_ctx.append(spec_typeid)
     if project_id:
         process_ctx.append(TypeId(type=BuiltinEntityType.PROJECT.value, id=project_id))
 
     draft_ctx: list[TypeId] = [TypeId(type=BuiltinEntityType.TASK.value, id=task.id)]
-    if task.conversation_id:
-        draft_ctx.append(TypeId(type=BuiltinEntityType.CONVERSATION.value, id=task.conversation_id))
+    if conv_typeid:
+        draft_ctx.append(conv_typeid)
 
     return HeadlessRunScope(
         target_typeid=TypeId(type=BuiltinEntityType.TASK.value, id=task.id),
-        conversation_id=task.conversation_id or "",
+        conversation_id=conv_typeid.id if conv_typeid else "",
         workdir=(task.project_root or "").strip(),
         project_id=project_id,
         process_context=process_ctx,

--- a/flow_sdk/builtin/flow_message.py
+++ b/flow_sdk/builtin/flow_message.py
@@ -19,6 +19,15 @@ class AttachmentType(str, Enum):
     PROMPT = "prompt"
 
 
+# VFS subpath prefixes for binary attachment storage. Sender and receiver use
+# the same layout so /fs/download/ resolves identically on both sides:
+#   FILE  attachments → data/<filename>
+#   PROMPT-with-file  → prompt/<filename>
+# Inline-text PROMPT attachments don't use a prefix — their `data` is the text.
+FILE_VFS_PREFIX = "data/"
+PROMPT_FILE_VFS_PREFIX = "prompt/"
+
+
 class Attachment(BaseModel):
     """A single item attached to a FlowMessage.
 
@@ -79,7 +88,7 @@ class FlowMessage(Entity):
                     att["local_path"] = storage.get_storage_path(att.get("data", ""))
                 elif att.get("attachment_type") == AttachmentType.PROMPT.value:
                     raw = att.get("data", "")
-                    if raw and raw.startswith("prompt/"):
+                    if raw and raw.startswith(PROMPT_FILE_VFS_PREFIX):
                         att["local_path"] = storage.get_storage_path(raw)
         return data
 

--- a/flow_sdk/cli/auth/cloud_login.py
+++ b/flow_sdk/cli/auth/cloud_login.py
@@ -4,7 +4,7 @@
 (POST cloud /login with ``FLOWPAD_CLOUD_USER_EMAIL`` /
 ``FLOWPAD_CLOUD_USER_PASSWORD``) or browser-mode (open the system browser
 to the cloud's login form, wait for the cloud's redirect to
-``/api/v1/cloud/post_login``).
+``/auth/login_callback``).
 
 Both paths converge on ``_finalize_login``, which broadcasts the success
 WS event and persists the bearer token + user.
@@ -71,7 +71,7 @@ async def _login_by_window(port: int, timeout: float) -> dict[str, Any]:
     state.login_result = None
     asyncio.create_task(_wait_or_timeout(timeout))
 
-    url = get_login_url(f"http://127.0.0.1:{port}/api/v1/cloud/post_login")
+    url = get_login_url(f"http://127.0.0.1:{port}/auth/login_callback")
     await asyncio.to_thread(webbrowser.open, url)
     return {"status": "started", "url": url}
 

--- a/flow_sdk/cli/config_manager.py
+++ b/flow_sdk/cli/config_manager.py
@@ -14,7 +14,7 @@ class ConfigKey(Enum):
     """Enumerated config keys with their default values."""
     FLOWPAD_API_SERVER_HOST = "localhost:8000"
     LOGIN_URL = "localhost:5173"
-    POST_LOGIN_TIMEOUT = "30"
+    LOGIN_CALLBACK_TIMEOUT = "30"
 
 
 def load_config():

--- a/flow_sdk/cli/flow_cli.py
+++ b/flow_sdk/cli/flow_cli.py
@@ -440,7 +440,7 @@ def auth_login(
         import asyncio
 
         from flow_sdk.cli.auth.cloud_login import cloud_login
-        from flow_sdk.server.app import wait_for_post_login
+        from flow_sdk.server.app import wait_for_login_callback
 
         typer.echo("\n🌊 Logging in to Flowpad...")
         try:
@@ -456,7 +456,7 @@ def auth_login(
         else:
             # Browser-mode: cloud_login opened the system browser; wait for the callback.
             typer.echo(f"Opened browser: {launch['url']}\n")
-            result = wait_for_post_login()
+            result = wait_for_login_callback()
             if result.get("success"):
                 typer.echo("\n✓ Successfully logged in to Flowpad")
                 typer.echo("✓ API key stored securely in system keyring")
@@ -501,12 +501,12 @@ def auth_test(delay: Annotated[int, typer.Option(help="Delay in seconds before a
     """
     import webbrowser
 
-    from flow_sdk.server.app import wait_for_post_login
+    from flow_sdk.server.app import wait_for_login_callback
 
     port = _discover_port()
 
     # Build the test login URL with callback and delay
-    callback_url = f"http://127.0.0.1:{port}/api/v1/cloud/post_login"
+    callback_url = f"http://127.0.0.1:{port}/auth/login_callback"
     test_login_url = f"http://127.0.0.1:{port}/api/v1/cloud/test_login?callback={callback_url}&delay={delay}"
 
     typer.echo(f"\n🧪 Opening test login page with {delay} second delay...")
@@ -516,7 +516,7 @@ def auth_test(delay: Annotated[int, typer.Option(help="Delay in seconds before a
     webbrowser.open(test_login_url)
 
     # Wait for the login callback
-    result = wait_for_post_login()
+    result = wait_for_login_callback()
 
     if result.get("success"):
         typer.echo("\n✓ Test login successful!")

--- a/flow_sdk/fs_records/flow_message_bundle.py
+++ b/flow_sdk/fs_records/flow_message_bundle.py
@@ -52,7 +52,7 @@ _TASK_FIELDS = {"type", "id", "title", "description", "status", "task_type",
 if TYPE_CHECKING:
     from flow_sdk.builtin.flow_message import FlowMessage
 
-from flow_sdk.builtin.flow_message import AttachmentType
+from flow_sdk.builtin.flow_message import AttachmentType, FILE_VFS_PREFIX, PROMPT_FILE_VFS_PREFIX
 
 
 def _json_default(obj):
@@ -91,7 +91,7 @@ def _write_top_level_header(flow_message: "FlowMessage", tmp_root: Path) -> None
     )
     for att in msg_data.get("attachment", []):
         raw = att.get("data", "")
-        if raw.startswith("data/") or raw.startswith("prompt/"):
+        if raw.startswith(FILE_VFS_PREFIX) or raw.startswith(PROMPT_FILE_VFS_PREFIX):
             att["data"] = f"attachment/files/{Path(raw).name}"
     (tmp_root / "header.json").write_text(
         json.dumps(msg_data, default=_json_default, ensure_ascii=False), encoding="utf-8"
@@ -111,7 +111,7 @@ def _pack_file_attachment(entry, flow_message: "FlowMessage", attachment_dir: Pa
     from flow_sdk.storage import get_entity_embedded_storage
 
     raw = entry.data or ""
-    if not (raw.startswith("data/") or raw.startswith("prompt/")):
+    if not (raw.startswith(FILE_VFS_PREFIX) or raw.startswith(PROMPT_FILE_VFS_PREFIX)):
         return
     storage = get_entity_embedded_storage(flow_message.typeid)
     file_path = Path(storage.get_storage_path(raw))
@@ -315,9 +315,9 @@ def _rewrite_file_attachments(fm_data: dict, tmp_root: Path, fm_id: str) -> None
         if not rel_path.startswith("attachment/files/"):
             continue
         if att_type == AttachmentType.FILE.value:
-            vfs_prefix = "data"
+            vfs_prefix = FILE_VFS_PREFIX.rstrip("/")
         elif att_type == AttachmentType.PROMPT.value:
-            vfs_prefix = "prompt"
+            vfs_prefix = PROMPT_FILE_VFS_PREFIX.rstrip("/")
         else:
             continue
         src = tmp_root / rel_path

--- a/flow_sdk/fs_records/flow_message_bundle.py
+++ b/flow_sdk/fs_records/flow_message_bundle.py
@@ -78,9 +78,11 @@ class FlowMessageExistsError(Exception):
 def _write_top_level_header(flow_message: "FlowMessage", tmp_root: Path) -> None:
     """Serialize the FlowMessage's own fields to ``<root>/header.json``.
 
-    FILE attachments are stored locally as VFS subpaths (e.g. ``data/file.txt``)
-    but the receiver locates them at ``attachment/files/<basename>`` inside
-    the zip — rewrite the ``data`` field accordingly so both sides agree.
+    Binary attachments are stored locally as VFS subpaths (FILE: ``data/<name>``,
+    PROMPT-with-file: ``prompt/<name>``) but the receiver locates them at
+    ``attachment/files/<basename>`` inside the zip — rewrite the ``data``
+    field accordingly so both sides agree. Inline-text PROMPT attachments
+    (data is the prompt text, not a VFS path) have no file and pass through.
     """
     msg_data = flow_message.model_dump(
         mode="python",
@@ -88,19 +90,31 @@ def _write_top_level_header(flow_message: "FlowMessage", tmp_root: Path) -> None
         context={"skip_api_serializer": True},
     )
     for att in msg_data.get("attachment", []):
-        if att.get("attachment_type") == AttachmentType.FILE.value:
-            att["data"] = f"attachment/files/{Path(att['data']).name}"
+        raw = att.get("data", "")
+        if raw.startswith("data/") or raw.startswith("prompt/"):
+            att["data"] = f"attachment/files/{Path(raw).name}"
     (tmp_root / "header.json").write_text(
         json.dumps(msg_data, default=_json_default, ensure_ascii=False), encoding="utf-8"
     )
 
 
 def _pack_file_attachment(entry, flow_message: "FlowMessage", attachment_dir: Path) -> None:
-    """Copy a single FILE attachment from local VFS storage into ``attachment/files/``."""
+    """Copy a binary attachment (FILE or PROMPT-with-file) into ``attachment/files/``.
+
+    The local VFS layout (``data/<name>`` for FILE, ``prompt/<name>`` for
+    PROMPT-with-file) tells us whether bytes exist on disk. Inline-text
+    PROMPT attachments (no path prefix) are skipped — their text rides on
+    header.json. The receiver's ``_rewrite_file_attachments`` re-splits FILE
+    vs. PROMPT into ``data/`` / ``prompt/`` based on ``attachment_type``,
+    so the zip uses a single ``files/`` dir for both.
+    """
     from flow_sdk.storage import get_entity_embedded_storage
 
+    raw = entry.data or ""
+    if not (raw.startswith("data/") or raw.startswith("prompt/")):
+        return
     storage = get_entity_embedded_storage(flow_message.typeid)
-    file_path = Path(storage.get_storage_path(entry.data))
+    file_path = Path(storage.get_storage_path(raw))
     if not file_path.exists():
         return
     files_dir = attachment_dir / "files"
@@ -196,7 +210,7 @@ async def _pack_attachment_entry(
 
     Repo/URL attachments have no bytes to bundle — silently skipped.
     """
-    if entry.attachment_type == AttachmentType.FILE:
+    if entry.attachment_type in (AttachmentType.FILE, AttachmentType.PROMPT):
         _pack_file_attachment(entry, flow_message, attachment_dir)
         return
     if entry.attachment_type != AttachmentType.TYPE_ID:
@@ -283,24 +297,33 @@ def _read_entity_header(entity_dir: Path) -> dict | None:
 
 
 def _rewrite_file_attachments(fm_data: dict, tmp_root: Path, fm_id: str) -> None:
-    """Copy FILE attachments from the extracted zip into the FlowMessage's embedded
-    storage and rewrite their `data` field to a VFS subpath (data/{filename}).
+    """Copy binary attachments from the extracted zip into the FlowMessage's embedded
+    storage and rewrite their `data` field to the receiver-side VFS subpath.
 
-    This mirrors how the sender stores files so that fs/download works identically
-    for both sender and recipient.
+    FILE attachments land at ``data/<filename>``; PROMPT-with-file attachments
+    land at ``prompt/<filename>`` — the same layout the sender uses, so
+    ``/fs/download/`` resolves identically on both sides. Inline-text PROMPT
+    attachments are passed through.
     """
     from flow_sdk.api.type_id import TypeId
     from flow_sdk.storage import get_entity_embedded_storage
     fm_typeid = TypeId(type="flow_message", id=fm_id)
     storage = get_entity_embedded_storage(fm_typeid)
     for att in fm_data.get("attachment", []):
-        if att.get("attachment_type") != AttachmentType.FILE.value:
-            continue
+        att_type = att.get("attachment_type")
         rel_path = att.get("data", "")
+        if not rel_path.startswith("attachment/files/"):
+            continue
+        if att_type == AttachmentType.FILE.value:
+            vfs_prefix = "data"
+        elif att_type == AttachmentType.PROMPT.value:
+            vfs_prefix = "prompt"
+        else:
+            continue
         src = tmp_root / rel_path
         if not src.exists():
             continue
-        vfs_subpath = f"data/{src.name}"
+        vfs_subpath = f"{vfs_prefix}/{src.name}"
         dest = Path(storage.get_storage_path(vfs_subpath))
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dest)

--- a/flow_sdk/server/app.py
+++ b/flow_sdk/server/app.py
@@ -38,6 +38,7 @@ from flow_sdk.server import FlowServer
 
 from .routes import (
     assets_router,
+    auth_router,
     cloud_router,
     chat_router,
     debug_router,
@@ -151,6 +152,7 @@ async def _shutdown_extras():
 
 
 server = FlowServer()
+server.add_router(auth_router)
 server.add_router(cloud_router)
 server.add_router(hooks_router)
 server.add_router(chat_router)
@@ -272,9 +274,9 @@ def start_server(port: int):
     uvicorn.run(app, host="127.0.0.1", port=port, log_level="warning")
 
 
-def wait_for_post_login(timeout_sec: int = None):
+def wait_for_login_callback(timeout_sec: int = None):
     """
-    Wait for the post_login endpoint to be called.
+    Wait for the login_callback endpoint to be called.
     Runs the server in a separate thread and waits for login.
 
     Args:
@@ -292,7 +294,7 @@ def wait_for_post_login(timeout_sec: int = None):
 
     # Get timeout from config if not provided
     if timeout_sec is None:
-        timeout_str = get_config_value("post_login_timeout")
+        timeout_str = get_config_value("login_callback_timeout")
         timeout_sec = int(timeout_str) if timeout_str else 30
 
     port = int(os.environ.get("LOCAL_SERVER_PORT", "9007"))

--- a/flow_sdk/server/routes/__init__.py
+++ b/flow_sdk/server/routes/__init__.py
@@ -3,6 +3,7 @@
 from .bootstrap import router as bootstrap_router
 from .graph import graph_router
 from .health import health_router
+from .auth import router as auth_router
 from .cloud import router as cloud_router
 from .hooks import router as hooks_router
 from .chat import router as chat_router
@@ -26,6 +27,7 @@ __all__ = [
     "bootstrap_router",
     "graph_router",
     "health_router",
+    "auth_router",
     "cloud_router",
     "hooks_router",
     "chat_router",

--- a/flow_sdk/server/routes/auth.py
+++ b/flow_sdk/server/routes/auth.py
@@ -1,0 +1,73 @@
+"""Top-level auth callback routes — mounted at ``/auth/*``.
+
+* ``GET /auth/login_callback`` — cloud's redirect target after browser-mode auth.
+                                  Path is referenced verbatim by the hub's
+                                  ``append_desktop_api_key`` (hub:
+                                  ``core/auth/providers/auth_provider.py``); both
+                                  the local-CLI login flow and the staging
+                                  landing-page "open in flowpad" deep-link land
+                                  here.
+
+The handler validates the api-key, finalizes the login, and either redirects to
+``next`` (same-origin path only) or renders the success page.
+"""
+
+from fastapi import APIRouter, Query
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import state
+from .cloud import _render_result_page
+
+router = APIRouter(prefix="/auth")
+
+
+@router.get("/login_callback", response_class=HTMLResponse)
+async def login_callback(
+    flowpad_api_key: str = Query(None, alias="flowpad-api-key"),
+    next: str = Query(None),
+):
+    """Cloud-redirect callback. Validates the api-key and finalizes the login.
+
+    `next` (same-origin path only) lets deep-link flows redirect back into the
+    SPA after a successful login.
+    """
+    try:
+        from flow_sdk.cli.auth.cloud_login import _finalize_login
+        from flow_sdk.cli.auth.hub_login import validate_api_key_async
+
+        if not flowpad_api_key:
+            raise ValueError("No API key provided. Expected 'flowpad-api-key' parameter.")
+
+        user_info = await validate_api_key_async(flowpad_api_key)
+        await _finalize_login(flowpad_api_key, user_info)
+
+        if next and next.startswith("/"):
+            return RedirectResponse(url=next, status_code=302)
+
+        user_id = user_info.get("id", "Unknown")
+        detail_html = f'<div class="detail-box"><strong>Account Details:</strong><br>User ID: {user_id}</div>'
+        return _render_result_page(
+            title="Login Successful",
+            heading="Login Successful!",
+            subheading="You have been successfully logged in to Flowpad.",
+            detail_html=detail_html,
+            color="#22c55e",
+            icon="✓",
+        )
+    except Exception as e:
+        from flow_sdk.cli.auth.cloud_login import _broadcast_oauth_error
+
+        state.login_result = {"success": False, "error": str(e), "message": "Login failed"}
+        state.login_received.set()
+        await _broadcast_oauth_error(str(e))
+
+        detail_html = f'<div class="detail-box"><strong>Error Details:</strong><br>{e}</div>'
+        return _render_result_page(
+            title="Login Failed",
+            heading="Login Failed",
+            subheading="There was an error during login.",
+            detail_html=detail_html,
+            color="#ef4444",
+            icon="✗",
+            status_code=400,
+        )

--- a/flow_sdk/server/routes/cloud.py
+++ b/flow_sdk/server/routes/cloud.py
@@ -4,23 +4,19 @@
 * ``POST   /login``            — env-mode (synchronous) or browser-mode
                                  (returns "started" + URL, completion via WS)
 * ``POST   /logout``           — clear keyring + user JSON; return cloud logout URL
-* ``GET    /post_login``       — cloud's redirect target after browser-mode auth.
-                                 Path must contain ``/post_login`` because the hub's
-                                 ``append_desktop_api_key`` only appends ``flowpad-api-key``
-                                 to redirects whose path matches that substring
-                                 (hub: ``core/auth/providers/auth_provider.py``).
 * ``GET    /logout_callback``  — cloud's redirect target after logout
 * ``POST   /refresh-token``    — local-dev stub
+
+The browser-mode login callback lives at ``/auth/login_callback`` — see
+``flow_sdk/server/routes/auth.py``.
 """
 
 from pathlib import Path
 
-from fastapi import APIRouter, Query
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse, JSONResponse
 
 from flow_sdk.responses.response import ApiFailResponse, ApiSuccessResponse
-
-from .. import state
 
 router = APIRouter(prefix="/api/v1/cloud")
 
@@ -97,63 +93,6 @@ def _render_result_page(
 </body>
 </html>"""
     return HTMLResponse(content=html_content, status_code=status_code)
-
-
-# ---------------------------------------------------------------------------
-# Browser-mode callback (cloud redirects here after auth)
-# ---------------------------------------------------------------------------
-
-
-@router.get("/post_login", response_class=HTMLResponse)
-async def post_login(
-    flowpad_api_key: str = Query(None, alias="flowpad-api-key"),
-    next: str = Query(None),
-):
-    """Cloud-redirect callback. Validates the api-key and finalizes the login.
-
-    `next` (same-origin path only) lets deep-link flows redirect back into the
-    SPA after a successful login.
-    """
-    try:
-        from flow_sdk.cli.auth.cloud_login import _finalize_login
-        from flow_sdk.cli.auth.hub_login import validate_api_key_async
-
-        if not flowpad_api_key:
-            raise ValueError("No API key provided. Expected 'flowpad-api-key' parameter.")
-
-        user_info = await validate_api_key_async(flowpad_api_key)
-        await _finalize_login(flowpad_api_key, user_info)
-
-        if next and next.startswith("/"):
-            return RedirectResponse(url=next, status_code=302)
-
-        user_id = user_info.get("id", "Unknown")
-        detail_html = f'<div class="detail-box"><strong>Account Details:</strong><br>User ID: {user_id}</div>'
-        return _render_result_page(
-            title="Login Successful",
-            heading="Login Successful!",
-            subheading="You have been successfully logged in to Flowpad.",
-            detail_html=detail_html,
-            color="#22c55e",
-            icon="✓",
-        )
-    except Exception as e:
-        from flow_sdk.cli.auth.cloud_login import _broadcast_oauth_error
-
-        state.login_result = {"success": False, "error": str(e), "message": "Login failed"}
-        state.login_received.set()
-        await _broadcast_oauth_error(str(e))
-
-        detail_html = f'<div class="detail-box"><strong>Error Details:</strong><br>{e}</div>'
-        return _render_result_page(
-            title="Login Failed",
-            heading="Login Failed",
-            subheading="There was an error during login.",
-            detail_html=detail_html,
-            color="#ef4444",
-            icon="✗",
-            status_code=400,
-        )
 
 
 @router.get("/logout_callback", response_class=HTMLResponse)

--- a/tests/api/test_cloud_login_flow.py
+++ b/tests/api/test_cloud_login_flow.py
@@ -6,8 +6,8 @@ Endpoints covered (defined in flow_sdk/server/routes/cloud.py):
   - POST /api/v1/cloud/login             -> env-mode {status:"logged_in"} or browser-mode {status:"started", url}
   - POST /api/v1/cloud/logout            -> {cloud_logout_url}
   - POST /api/v1/cloud/refresh-token     -> "local_dev_token_refresh" string
-  - GET  /api/v1/cloud/login_callback    -> success/error HTML page (replaces old /post_login)
-  - GET  /api/v1/cloud/logout_callback   -> success HTML page (replaces old /post_logout)
+  - GET  /auth/login_callback            -> success/error HTML page
+  - GET  /api/v1/cloud/logout_callback   -> success HTML page
   - GET  /api/v1/graph/bootstrap         -> desktop_info.cloud_login_available
 
 Mocked targets (existing module paths still in use after the refactor):
@@ -112,13 +112,13 @@ async def test_login_chokepoint_failure_returns_400(client):
 
 
 # ---------------------------------------------------------------------------
-# GET /api/v1/cloud/login_callback (cloud redirect target — replaces old /post_login)
+# GET /auth/login_callback (cloud redirect target)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_login_callback_returns_success_html(client):
-    """GET /api/v1/cloud/login_callback?flowpad-api-key=<key> returns 200 with success HTML."""
+    """GET /auth/login_callback?flowpad-api-key=<key> returns 200 with success HTML."""
     with (
         patch(
             "flow_sdk.cli.auth.hub_login.validate_api_key_async",
@@ -128,7 +128,7 @@ async def test_login_callback_returns_success_html(client):
         patch("flow_sdk.cli.app_config.set_user"),
     ):
         response = await client.get(
-            f"/api/v1/cloud/login_callback?flowpad-api-key={TEST_API_KEY}"
+            f"/auth/login_callback?flowpad-api-key={TEST_API_KEY}"
         )
 
     assert response.status_code == 200
@@ -137,7 +137,7 @@ async def test_login_callback_returns_success_html(client):
 
 @pytest.mark.asyncio
 async def test_login_callback_full_flow_finalizes_login(client):
-    """GET /api/v1/cloud/login_callback validates key, persists creds, signals login_received."""
+    """GET /auth/login_callback validates key, persists creds, signals login_received."""
     from flow_sdk.server import state
 
     with (
@@ -154,7 +154,7 @@ async def test_login_callback_full_flow_finalizes_login(client):
         state.login_received.clear()
 
         response = await client.get(
-            f"/api/v1/cloud/login_callback?flowpad-api-key={TEST_API_KEY}"
+            f"/auth/login_callback?flowpad-api-key={TEST_API_KEY}"
         )
 
     assert response.status_code == 200
@@ -168,8 +168,8 @@ async def test_login_callback_full_flow_finalizes_login(client):
 
 @pytest.mark.asyncio
 async def test_login_callback_missing_key_returns_400(client):
-    """GET /api/v1/cloud/login_callback with no key returns 400 + Login Failed HTML."""
-    response = await client.get("/api/v1/cloud/login_callback")
+    """GET /auth/login_callback with no key returns 400 + Login Failed HTML."""
+    response = await client.get("/auth/login_callback")
 
     assert response.status_code == 400
     assert "Login Failed" in response.text
@@ -178,13 +178,13 @@ async def test_login_callback_missing_key_returns_400(client):
 
 @pytest.mark.asyncio
 async def test_login_callback_invalid_key_returns_400(client):
-    """GET /api/v1/cloud/login_callback with a key that fails validation returns 400."""
+    """GET /auth/login_callback with a key that fails validation returns 400."""
     with patch(
         "flow_sdk.cli.auth.hub_login.validate_api_key_async",
         new=AsyncMock(side_effect=Exception("Invalid API key")),
     ):
         response = await client.get(
-            f"/api/v1/cloud/login_callback?flowpad-api-key={TEST_API_KEY}"
+            f"/auth/login_callback?flowpad-api-key={TEST_API_KEY}"
         )
 
     assert response.status_code == 400
@@ -194,7 +194,7 @@ async def test_login_callback_invalid_key_returns_400(client):
 
 @pytest.mark.asyncio
 async def test_login_callback_invalidates_bootstrap_cache(client):
-    """GET /api/v1/cloud/login_callback clears the bootstrap cache so the next fetch reflects logged-in state."""
+    """GET /auth/login_callback clears the bootstrap cache so the next fetch reflects logged-in state."""
     import flow_sdk.server.routes.bootstrap as bootstrap_mod
 
     bootstrap_mod._bootstrap_cache = {"some": "stale_data"}
@@ -208,7 +208,7 @@ async def test_login_callback_invalidates_bootstrap_cache(client):
         patch("flow_sdk.cli.app_config.set_user"),
     ):
         response = await client.get(
-            f"/api/v1/cloud/login_callback?flowpad-api-key={TEST_API_KEY}"
+            f"/auth/login_callback?flowpad-api-key={TEST_API_KEY}"
         )
 
     assert response.status_code == 200
@@ -217,7 +217,7 @@ async def test_login_callback_invalidates_bootstrap_cache(client):
 
 @pytest.mark.asyncio
 async def test_login_callback_broadcasts_oauth_message(client):
-    """GET /api/v1/cloud/login_callback broadcasts an OAuthMessage with provider=flowpad_cloud + status=success."""
+    """GET /auth/login_callback broadcasts an OAuthMessage with provider=flowpad_cloud + status=success."""
     broadcast_calls: list[dict] = []
 
     async def _capture(message: str) -> None:
@@ -233,7 +233,7 @@ async def test_login_callback_broadcasts_oauth_message(client):
         patch("flow_sdk.server.routes.websocket.broadcast", side_effect=_capture),
     ):
         response = await client.get(
-            f"/api/v1/cloud/login_callback?flowpad-api-key={TEST_API_KEY}"
+            f"/auth/login_callback?flowpad-api-key={TEST_API_KEY}"
         )
 
     assert response.status_code == 200

--- a/ui/src/components/conversation/prompt-building.ts
+++ b/ui/src/components/conversation/prompt-building.ts
@@ -90,12 +90,26 @@ export async function buildMergedPrompt(flowMessage: FlowMessage): Promise<strin
   return [...inlineParts, ...promptFilePaths, ...fileContext].join('\n\n');
 }
 
-/** POST `approve-prompt` and refetch the FlowMessage so PROMPT.local_path / approved_by are populated. */
+/** POST `approve-prompt`, then refetch the FlowMessage and nudge cache subscribers
+ * so the approve-and-execute button re-evaluates immediately — don't wait for the
+ * backend's WS UPDATE round-trip (which has been observed to land late or miss
+ * `useEntity` consumers, leaving the button visible after a successful approve).
+ *
+ * `invalidateCacheByTypeId` drops the stale entry so `getByTypeId` re-fetches
+ * from the server (with the new `approved_by` populated and `local_path`
+ * resolved); `notifyEntityChanged` then ticks every watched query for the
+ * `flow_message` type so React subscribers re-render against the fresh data.
+ */
 export async function approveAndReload(messageId: string, attachmentIndex: number): Promise<FlowMessage | null> {
   const approveAction = new ActionInfo('approve-prompt', 'flow_message', messageId, 'POST');
   approveAction.bodyParameters = { attachment_index: attachmentIndex, approve_all: true };
   await dataManager.callAction(approveAction);
-  return dataManager
-    .getByTypeId<FlowMessage>(new TypeId(FlowMessage.type, messageId))
-    .catch(() => null);
+
+  const typeId = new TypeId(FlowMessage.type, messageId);
+  dataManager.invalidateCacheByTypeId(typeId);
+  const fm = await dataManager.getByTypeId<FlowMessage>(typeId).catch(() => null);
+  if (fm) {
+    dataManager.notifyEntityChanged(fm);
+  }
+  return fm;
 }


### PR DESCRIPTION
## Summary

Two related changes on the FLOWPAD-1852 branch:

**1. Align scenario B (plain hub-mirrored conversations) with A/C bundle delivery.**
Previously, plain home-landing conversation messages uploaded each blob individually to per-file hub URLs and the receiver lazy-fetched on first click. After this change, scenario B uses the same `.flowmsg` bundle path as task-bound replies: pack once, upload once, receiver downloads + unpacks atomically. Removes the receiver-side lazy-fetch hop and makes the bundle layout the only delivery model.

- New unified packer in `flow_sdk/fs_records/flow_message_bundle.py`: FILE and PROMPT-with-file blobs share `attachment/files/`; receiver routes them back to `data/<name>` / `prompt/<name>` based on `attachment_type`. Magic strings replaced with `FILE_VFS_PREFIX` / `PROMPT_FILE_VFS_PREFIX` constants in `flow_sdk/builtin/flow_message.py`.
- `_handle_hub_mirrored_append` → renamed to `_handle_plain_conversation_append` (the conversation is what's hub-mirrored, not the delivery method). Pre-stamps `attachment_filename` via the `add_message` body so the member-role sender doesn't need a follow-up PUT (which they lack permission for); calls a new PUT-free `_pack_and_upload_bundle` helper. Task-bound path keeps the PUT-based `_upload_bundle_to_hub`.
- `handle_conversation_sync` now downloads + unpacks the bundle when `attachment_filename` is set; falls back to metadata-only mirror for text-only messages.
- FE: `approveAndReload` invalidates the FlowMessage cache and calls `notifyEntityChanged` so the approve-and-execute button re-renders against fresh data without waiting for the WS round-trip.

**2. `post_login` → `login_callback` route rename + new top-level `/auth` router.**
Hub LP "Open in FlowPad" deep-links land at `/auth/login_callback` instead of `/post_login` (the old route was deleted in the cloud-auth consolidation refactor on May 2 and never aliased back). Internal CLI callers, config key (`POST_LOGIN_TIMEOUT` → `LOGIN_CALLBACK_TIMEOUT`), and tests updated.

## Test plan

- [ ] Plain conversation B: user 1 sends prompt + prompt-file → user 2 syncs → user 2 clicks attachment → 200, file streams from local fs (no lazy-fetch round-trip)
- [ ] Plain conversation B as member: user 2 (member, not owner) sends a reply with attachment → no 401 PUT in logs → user 1 receives bundle and can open the attachment
- [ ] Task-bound A/C: existing reply-with-attachment flow still delivers via bundle (no regression in `_send_reply_to_hub`)
- [ ] Approve-and-execute button hides immediately after a successful approve (no manual refresh required)
- [ ] Runs drawer shows the new run on first turn (no manual refresh)
- [ ] Staging LP "Open in FlowPad" deep-link lands on `/auth/login_callback` and authenticates correctly
- [ ] `flow auth login` browser flow still completes end-to-end (uses the renamed callback URL internally)
- [ ] `tests/api/test_cloud_login_flow.py` passes against the renamed route

🤖 Generated with [Claude Code](https://claude.com/claude-code)