### PR TITLE
[codex] Fix worker history restore context

### DIFF
--- a/flow_sdk/builtin/agent.py
+++ b/flow_sdk/builtin/agent.py
@@ -29,5 +29,5 @@ class Agent(Entity):
     name: str | None = APIField(default=None)
     description: str | None = APIField(default=None)
     asset_ref: str = APIField(default="")
-    _api_visible: bool = True
+    _api_visible: ClassVar[bool] = True
     _icon: ClassVar[str] = "Bot"

--- a/flow_sdk/builtin/agentic_process/agentic_process.py
+++ b/flow_sdk/builtin/agentic_process/agentic_process.py
@@ -591,8 +591,10 @@ class AgenticProcess(Entity):
             await self.reap_if_orphaned()
             _bench("after reap_if_orphaned")
             self.session_id = self.session_id or str(uuid4())
-            if visible is not None:
+            reattach_changed = False
+            if visible is not None and self.visible != visible:
                 self.visible = visible
+                reattach_changed = True
 
             shell = await self.shell() if self.shell_id else None
             _bench("after self.shell()")
@@ -617,6 +619,8 @@ class AgenticProcess(Entity):
                 ):
                     if self.status != ProcessStatus.RUNNING.value:
                         self.status = ProcessStatus.RUNNING.value
+                        reattach_changed = True
+                    if reattach_changed:
                         await self.save()
                     return ApiSuccessResponse(data=self._build_open_payload(shell, is_resume=False))
                 # Gate failed (PTY dead, worker dead, or both). Drop the stale

--- a/flow_sdk/builtin/faas/scan_actions.py
+++ b/flow_sdk/builtin/faas/scan_actions.py
@@ -432,21 +432,100 @@ class ScanActionsMixin:
             cli_factory_key = "codex" if is_codex else "claude"
             wt_enum = WorkerType.CODEX if is_codex else WorkerType.CLAUDE_CODE
 
+            # Resolve workdir + project + project_encoded_name from the session record
+            # before checking for an existing process. The transcript cwd is the
+            # authoritative restore location; project_id is derived from it so
+            # worktrees and nested checkouts do not collapse into the active dock
+            # project.
+            project_encoded_name = None
+            session_name: str | None = None
+            session_rec = None
+            try:
+                from flow_sdk.builtin.project import Project
+
+                if is_codex:
+                    from flow_sdk.fs_records.codex import CodexSessionRecord
+                    session_rec = CodexSessionRecord.get(session_id)
+                else:
+                    from flow_sdk.fs_records.claude.claude_session import ClaudeSessionRecord
+                    session_rec = ClaudeSessionRecord.get(session_id)
+
+                if session_rec:
+                    rec_cwd = getattr(session_rec, "cwd", None)
+                    if rec_cwd and not workdir:
+                        workdir = rec_cwd
+                    project_encoded_name = getattr(session_rec, "project_encoded_name", None)
+                    rec_name = getattr(session_rec, "name", None) or ""
+                    if rec_name and rec_name != session_id:
+                        session_name = rec_name
+
+                if workdir:
+                    project = await Project.recover_by_path(workdir)
+                    if project:
+                        project_id = project.id
+                        project_encoded_name = project.project_encoded_name or project_encoded_name
+                elif project_id:
+                    project = await Project.get_by_id(project_id)
+                    if project and not project_encoded_name:
+                        project_encoded_name = project.project_encoded_name
+            except Exception:
+                logging.debug(
+                    "ComputeNode %s upsertSessionProcess session context resolve failed for %s",
+                    self.id,
+                    session_id,
+                    exc_info=True,
+                )
+
             # Try to find existing process by session_id
             existing = await AgenticProcess.get_all(
                 entities_filter=QueryFilter(match=ExpressionNode(session_id=session_id))
             )
             if existing:
                 process = existing[0]
-                # Re-tag the AgenticProcess to the request body's project_id
-                # when it drifts. The dock-active project is authoritative for
-                # which strip the row should appear in; a stale `project_id`
-                # left over from a prior resume in a different project context
-                # would otherwise cause the freshly-spawned Shell (Fix #30) to
-                # be tagged wrong and `useProjectTerminals` would drop the row.
+                changed = False
+                context_data = dict(process.context_data or {})
+                if workdir and process.workdir != workdir:
+                    process.workdir = workdir
+                    changed = True
+                if workdir and context_data.get("workdir") != workdir:
+                    context_data["workdir"] = workdir
+                    changed = True
                 if project_id and process.project_id != project_id:
                     process._bind_project_id(project_id)
+                    changed = True
+                if project_id and context_data.get("project_id") != project_id:
+                    context_data["project_id"] = project_id
+                    changed = True
+                if project_encoded_name and process.project_encoded_name != project_encoded_name:
+                    process.project_encoded_name = project_encoded_name
+                    changed = True
+                if session_name and not process.name:
+                    process.name = session_name
+                    changed = True
+                if changed:
+                    process.context_data = context_data
                     await process.save()
+                if process.shell_id and (workdir or project_id):
+                    try:
+                        from flow_sdk.builtin.shell import Shell
+
+                        shell = await Shell.get_by_id(process.shell_id)
+                        shell_changed = False
+                        if shell and workdir and shell.workdir != workdir:
+                            shell.workdir = workdir
+                            shell_changed = True
+                        if shell and project_id and shell.project_id != project_id:
+                            shell.project_id = project_id
+                            shell_changed = True
+                        if shell and shell_changed:
+                            await shell.save()
+                    except Exception:
+                        logging.debug(
+                            "ComputeNode %s upsertSessionProcess shell context heal failed for %s",
+                            self.id,
+                            process.id,
+                            exc_info=True,
+                        )
                 # Heal pre-existing processes that were persisted before the
                 # atomic-start fix: ensure the linked Shell + PTY are attached
                 # and the process is visible so the tab strip will surface it.
@@ -473,40 +552,6 @@ class ScanActionsMixin:
                         "created": False,
                     }
                 )
-
-            # Resolve workdir + project + project_encoded_name from the session record.
-            project_encoded_name = None
-            session_name: str | None = None
-            session_rec = None
-            try:
-                from flow_sdk.builtin.project import Project
-
-                if is_codex:
-                    from flow_sdk.fs_records.codex import CodexSessionRecord
-                    session_rec = CodexSessionRecord.get(session_id)
-                else:
-                    from flow_sdk.fs_records.claude.claude_session import ClaudeSessionRecord
-                    session_rec = ClaudeSessionRecord.get(session_id)
-
-                if session_rec:
-                    rec_cwd = getattr(session_rec, "cwd", None)
-                    if rec_cwd and not workdir:
-                        workdir = rec_cwd
-                    project_encoded_name = getattr(session_rec, "project_encoded_name", None)
-                    rec_name = getattr(session_rec, "name", None) or ""
-                    if rec_name and rec_name != session_id:
-                        session_name = rec_name
-                if workdir and not project_id:
-                    projects = await Project.get_all()
-                    best, best_len = None, 0
-                    for p in projects:
-                        mp = getattr(p, "fs_storage_mount_path", None)
-                        if mp and workdir.startswith(str(mp)) and len(mp) > best_len:
-                            best, best_len = p, len(mp)
-                    if best:
-                        project_id = best.id
-            except Exception:
-                pass
 
             # Create new process directly on this compute node
             owner = request_info.someone_typeid if request_info else None

--- a/flow_sdk/fs_records/codex/codex_session.py
+++ b/flow_sdk/fs_records/codex/codex_session.py
@@ -10,7 +10,7 @@ Mirrors ``ClaudeSessionRecord`` (``flow_sdk/fs_records/claude/claude_session.py`
 - Lazy stats via ``_CodexSessionStatsProp`` descriptors that share one
   ``_codex_session_batch_stats`` cache populated on first access.
 - ``discover()`` walks the date-bucketed sessions tree without parsing.
-- ``from_jsonl()`` does an O(1) head read for envelope fields.
+- ``from_jsonl()`` does a bounded first-lines read for envelope fields.
 
 Read-only: rollouts are owned by Codex itself; we never write back.
 """
@@ -29,7 +29,20 @@ from flow_sdk.instance_settings import get_instance_settings
 from .properties import _CodexSessionStatsProp
 
 
-_HEAD_BYTES = 8192  # session_meta lines can be large (base_instructions blob)
+_HEAD_LINES = 64
+
+
+def _iter_head_json(path: Path):
+    """Yield parsed JSON envelopes from the first few JSONL lines."""
+    with open(path, encoding="utf-8") as fh:
+        for _, line in zip(range(_HEAD_LINES), fh):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
 
 
 def _extract_thread_id(filename: str) -> str | None:
@@ -126,16 +139,7 @@ class CodexSessionRecord(Record):
     def getId(cls, ref) -> str:
         """Stable id = session_meta payload.id (the thread_id)."""
         try:
-            with ref._path.open("rb") as fh:
-                head = fh.read(_HEAD_BYTES).decode("utf-8", errors="replace")
-            for line in head.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    raw = json.loads(line)
-                except json.JSONDecodeError:
-                    break
+            for raw in _iter_head_json(ref._path):
                 if raw.get("type") == "session_meta":
                     payload = raw.get("payload") or {}
                     if payload.get("id"):
@@ -222,7 +226,7 @@ class CodexSessionRecord(Record):
     def from_jsonl(cls, path: str | Path) -> Self:
         """Build a session record from a rollout JSONL path.
 
-        Reads only the first ``_HEAD_BYTES`` to extract envelope fields (id,
+        Reads only the first few JSONL lines to extract envelope fields (id,
         cwd, version, originator). Stats are loaded lazily on first attribute
         access via ``_CodexSessionStatsProp`` descriptors.
         """
@@ -231,20 +235,9 @@ class CodexSessionRecord(Record):
         cwd = ""
         version = ""
         originator = ""
-        first_user_message: str | None = None
 
         try:
-            with open(path, "rb") as fh:
-                head = fh.read(_HEAD_BYTES).decode("utf-8", errors="replace")
-            for line in head.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    raw = json.loads(line)
-                except json.JSONDecodeError:
-                    # Boundary partial line — stop.
-                    break
+            for raw in _iter_head_json(path):
                 rtype = raw.get("type") or ""
                 if rtype == "session_meta":
                     payload = raw.get("payload") or {}
@@ -258,18 +251,6 @@ class CodexSessionRecord(Record):
                         originator = str(payload["originator"])
                 elif rtype == "thread.started" and raw.get("thread_id"):
                     session_id = str(raw["thread_id"])
-                elif rtype == "response_item" and first_user_message is None:
-                    payload = raw.get("payload") or {}
-                    if payload.get("type") == "message" and payload.get("role") == "user":
-                        for block in payload.get("content") or []:
-                            if isinstance(block, dict) and block.get("type") in (
-                                "input_text",
-                                "output_text",
-                            ):
-                                text = (block.get("text") or "").strip()
-                                if text and not text.startswith("<"):
-                                    first_user_message = text[:200]
-                                    break
         except OSError:
             pass
 
@@ -282,9 +263,4 @@ class CodexSessionRecord(Record):
             "source_file": str(path),
             "path": str(path),
         }
-        # Only seed last_user_message when we actually found one in the head;
-        # passing None would wedge the lazy stats descriptor (RecordField is a
-        # non-data descriptor — instance __dict__ wins over the lazy parse).
-        if first_user_message:
-            kwargs["last_user_message"] = first_user_message
         return cls(**kwargs)

--- a/flow_sdk/fs_records/worker_history.py
+++ b/flow_sdk/fs_records/worker_history.py
@@ -1,11 +1,11 @@
 """Unified worker history surface for the "Recent Sessions" UI.
 
-Per-worker providers (currently only ``get_claude_worker_history``) collect
+Per-worker providers (currently Claude and Codex) collect
 sessions from each agent's native history source. ``get_worker_history``
 merges, deduplicates, sorts and caps the combined list so the frontend can
 render it from a single response.
 
-Adding a new worker (e.g. codex) is a one-line addition to
+Adding a new worker is a one-line addition to
 ``WORKER_HISTORY_PROVIDERS``.
 """
 
@@ -127,7 +127,9 @@ def _build_agentic_process_index() -> dict[str, str]:
         logger.warning("[worker_history] discover agentic_process failed: %s", e)
         return index
     for rec in records:
-        sid = rec.worker_session_id
+        data = object.__getattribute__(rec, "__dict__")
+        cli_config = data.get("cli_config") if isinstance(data.get("cli_config"), dict) else {}
+        sid = rec.worker_session_id or data.get("session_id") or cli_config.get("session_id")
         if sid and sid not in index:
             index[sid] = rec.id
     return index

--- a/tests/api/test_agentic_process_resume_after_restart.py
+++ b/tests/api/test_agentic_process_resume_after_restart.py
@@ -244,41 +244,48 @@ async def test_open_registers_on_exit_so_status_updates(bootstrapped_client):
 
 
 @pytest.mark.asyncio
-async def test_open_is_idempotent_when_pty_alive(bootstrapped_client):
+async def test_open_is_idempotent_when_process_alive(bootstrapped_client):
     """
-    When the PTY is genuinely alive, process.open() must be a no-op: returns
-    SUCCESS without spawning a second shell process, and the shell_id is unchanged.
-
-    This is the normal case (no server restart) and must work after the fix.
-
-    After fix: open() detects alive PTY via Shell.start() and returns SUCCESS (no-op).
+    When the worker is genuinely alive, process.open() must be a fast no-op:
+    returns SUCCESS without replacing the running process/session.
     """
+    import time
+
     bootstrap = await bootstrapped_client.get("/api/v1/graph/bootstrap")
     cn_id = _compute_node_id(bootstrap)
     session_id = str(uuid.uuid4())
     jsonl_path = _make_fake_jsonl(session_id)
 
     try:
-        process_id, shell_id = await _create_post_restart_state(
+        process_id, _ = await _create_post_restart_state(
             bootstrapped_client, cn_id, session_id
         )
 
-        # Open a real PTY (simulates a genuinely alive shell)
-        shell_open_resp = await bootstrapped_client.post(
-            f"/api/v1/graph/shell/{shell_id}/open",
-            json={"cols": 80, "rows": 24},
-        )
-        assert ApiResponse(**shell_open_resp.json()).status == "SUCCESS", shell_open_resp.text
-
-        # process.open() on a live PTY must be a no-op — returns SUCCESS, same shell_id
-        open_resp = await bootstrapped_client.post(
+        first_resp = await bootstrapped_client.post(
             f"/api/v1/graph/agentic_process/{process_id}/open",
         )
-        open_result = ApiResponse(**open_resp.json())
-        assert open_result.status == "SUCCESS", open_result.message
-        assert open_result.data["shell_id"] == shell_id, (
-            "open() must reuse the existing shell when PTY is alive"
+        first_result = ApiResponse(**first_resp.json())
+        assert first_result.status == "SUCCESS", first_result.message
+        assert first_result.data["id"] == process_id
+        assert first_result.data["session_id"] == session_id
+        assert first_result.data["status"] == "running"
+        assert first_result.data["worker_pid"], "first open must start a worker"
+
+        start = time.perf_counter()
+        second_resp = await bootstrapped_client.post(
+            f"/api/v1/graph/agentic_process/{process_id}/open",
         )
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        second_result = ApiResponse(**second_resp.json())
+
+        assert second_result.status == "SUCCESS", second_result.message
+        assert second_result.data["id"] == process_id
+        assert second_result.data["session_id"] == session_id
+        assert second_result.data["status"] == "running"
+        assert second_result.data["worker_pid"] == first_result.data["worker_pid"], (
+            "second open must reuse the live worker"
+        )
+        assert elapsed_ms < 1000, f"second open took {elapsed_ms:.1f}ms"
 
     finally:
         jsonl_path.unlink(missing_ok=True)

--- a/tests/api/test_pty_process_e2e.py
+++ b/tests/api/test_pty_process_e2e.py
@@ -7,6 +7,7 @@ Tests both directions:
 
 import asyncio
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -109,6 +110,61 @@ async def test_upsert_session_process(bootstrapped_client):
     result2 = ApiResponse(**response.json())
     assert result2.data["created"] is False
     assert result2.data["id"] == process_id
+
+
+@pytest.mark.asyncio
+async def test_upsert_session_process_heals_existing_workdir(
+    bootstrapped_client,
+    tmp_path: Path,
+):
+    """Existing session processes adopt the history cwd on a later upsert."""
+    bootstrap = await bootstrapped_client.get("/api/v1/graph/bootstrap")
+    assert bootstrap.status_code == 200
+    compute_node_id = _get_default_compute_node_id(bootstrap.json())
+
+    test_session_id = f"test-{uuid.uuid4().hex[:8]}"
+
+    first = await bootstrapped_client.post(
+        f"/api/v1/graph/compute_node/{compute_node_id}/upsertSessionProcess",
+        json={"sessionId": test_session_id, "workdir": "/"},
+    )
+    assert first.status_code == 200, first.text
+    created = ApiResponse(**first.json()).data
+    process_id = created["id"]
+    before = await bootstrapped_client.get(f"/api/v1/graph/agentic_process/{process_id}")
+    assert before.status_code == 200, before.text
+    stale_project_id = ApiResponse(**before.json()).data["project_id"]
+
+    target_cwd = str(tmp_path / "worktree")
+    Path(target_cwd).mkdir()
+    healed = await bootstrapped_client.post(
+        f"/api/v1/graph/compute_node/{compute_node_id}/upsertSessionProcess",
+        json={
+            "sessionId": test_session_id,
+            "workdir": target_cwd,
+            "projectId": stale_project_id,
+        },
+    )
+    assert healed.status_code == 200, healed.text
+    healed_data = ApiResponse(**healed.json()).data
+    assert healed_data["created"] is False
+    assert healed_data["id"] == process_id
+
+    response = await bootstrapped_client.get(f"/api/v1/graph/agentic_process/{process_id}")
+    assert response.status_code == 200, response.text
+    process_entity = ApiResponse(**response.json()).data
+    assert process_entity["workdir"] == target_cwd
+    assert process_entity["context_data"]["workdir"] == target_cwd
+    assert process_entity["project_id"] != stale_project_id
+    assert process_entity["context_data"]["project_id"] == process_entity["project_id"]
+
+    shell_response = await bootstrapped_client.get(
+        f"/api/v1/graph/shell/{process_entity['shell_id']}"
+    )
+    assert shell_response.status_code == 200, shell_response.text
+    shell_entity = ApiResponse(**shell_response.json()).data
+    assert shell_entity["workdir"] == target_cwd
+    assert shell_entity["project_id"] == process_entity["project_id"]
 
 
 def test_flowpad_pty_pid_in_env():

--- a/tests/api/test_schema.py
+++ b/tests/api/test_schema.py
@@ -85,3 +85,18 @@ async def test_get_builtin_all_schema(bootstrapped_client):
     assert schemas is not None
     assert len(schemas) > 1
     print(f"Retrieved {len(schemas)} schemas")
+
+
+async def test_bootstrap_includes_agent_and_skill_schemas(bootstrapped_client):
+    client = bootstrapped_client
+
+    response = await client.get("/api/v1/graph/bootstrap")
+
+    assert response.status_code == 200, response.text
+    schemas: List[dict[str, Any]] = response.json()["data"]["schemas"]
+    schema_types = {
+        schema.get("properties", {}).get("type", {}).get("const")
+        for schema in schemas
+    }
+    assert "agent" in schema_types
+    assert "skill" in schema_types

--- a/tests/unit/test_agentic_process_api.py
+++ b/tests/unit/test_agentic_process_api.py
@@ -311,6 +311,36 @@ async def test_start_promotes_stuck_starting_process_to_live_when_pty_is_attacha
     get_project.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_start_persists_visible_true_on_running_reattach():
+    """Opening a hidden live process should make it visible without relaunching the worker."""
+    proc = _proc(
+        status=ProcessStatus.RUNNING.value,
+        shell_id="shell-123",
+        session_id="session-123",
+        visible=False,
+    )
+    shell = MagicMock()
+    shell.id = "shell-123"
+    shell.pty_pid = "pty-123"
+    shell.worker_pid = 4321
+    shell.model_dump.return_value = {"id": "shell-123"}
+    shell.ensure_live_compute_node_binding = AsyncMock(return_value=True)
+    shell.has_attachable_pty = AsyncMock(return_value=True)
+    shell.worker_alive = AsyncMock(return_value=True)
+
+    with patch.object(AgenticProcess, "shell", new=AsyncMock(return_value=shell)), \
+         patch.object(AgenticProcess, "save", new=AsyncMock()) as save, \
+         patch.object(AgenticProcess, "get_project", new=AsyncMock()) as get_project:
+        result = await proc.start(visible=True)
+
+    assert isinstance(result, ApiSuccessResponse)
+    assert proc.visible is True
+    assert proc.status == ProcessStatus.RUNNING.value
+    save.assert_awaited_once()
+    get_project.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # inject() — no-op when no shell
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_codex_fs_records/test_codex_session_record.py
+++ b/tests/unit/test_codex_fs_records/test_codex_session_record.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from flow_sdk.fs_records.codex import CodexSessionRecord
 from flow_sdk.fs_records.codex.codex_session import _extract_thread_id
 from flow_sdk.fs_store import RecordType
+from flow_sdk.fs_store.fs_ref import FSRef
 
 
 # do not increase timeout without approval
@@ -40,6 +42,40 @@ def test_from_jsonl_rollout_envelope(codex_sandbox: Path):
     assert rec.version == "0.101.0"
     assert rec.originator == "codex_cli_rs"
     assert rec.worker_type == "codex"
+
+
+def test_from_jsonl_reads_long_session_meta_line(tmp_path: Path):
+    session_id = "019cdd6b-49a7-7480-9da1-cccccccccccc"
+    rollout = tmp_path / f"rollout-2026-03-11T17-02-01-{session_id}.jsonl"
+    lines = [
+        {
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "cwd": "/Users/test/worktree",
+                "cli_version": "0.101.0",
+                "originator": "codex_cli_rs",
+                "base_instructions": "x" * 20000,
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "restore this session"}],
+            },
+        },
+    ]
+    rollout.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+    rec = CodexSessionRecord.from_jsonl(rollout)
+
+    assert CodexSessionRecord.getId(FSRef(rollout)) == session_id
+    assert rec.session_id == session_id
+    assert rec.cwd == "/Users/test/worktree"
+    assert rec.version == "0.101.0"
+    assert rec.last_user_message == "restore this session"
 
 
 def test_from_jsonl_lazy_stats(codex_sandbox: Path):

--- a/tests/unit/test_codex_fs_records/test_codex_worker_history.py
+++ b/tests/unit/test_codex_fs_records/test_codex_worker_history.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from flow_sdk.fs_records.worker_history import WorkerType, get_codex_worker_history
+
+
+def test_codex_worker_history_shape(codex_sandbox: Path):
+    entries = get_codex_worker_history(limit=5)
+
+    assert entries
+    entry = entries[0]
+    assert entry.worker_type == WorkerType.CODEX
+    assert entry.worker_id
+    assert entry.project_cwd in {"/repo", "/Users/test/proj_b"}
+    assert entry.project_name in {"repo", "proj_b"}
+    assert entry.last_active_time.tzinfo is not None
+    assert entry.name == "Add a small helper function that prints hello."
+    assert entry.message_count == 2

--- a/tests/unit/test_worker_history.py
+++ b/tests/unit/test_worker_history.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from flow_sdk.fs_records import worker_history as wh
+from flow_sdk.fs_records.worker_history import WorkerHistoryEntry, WorkerType
+
+
+def _entry(worker_type: WorkerType, worker_id: str, timestamp: str) -> WorkerHistoryEntry:
+    return WorkerHistoryEntry(
+        worker_type=worker_type,
+        worker_id=worker_id,
+        last_active_time=datetime.fromisoformat(timestamp).replace(tzinfo=timezone.utc),
+    )
+
+
+def test_get_worker_history_merges_sorts_and_limits(monkeypatch):
+    claude_mid = _entry(WorkerType.CLAUDE, "claude-mid", "2026-05-06T10:00:00")
+    claude_old = _entry(WorkerType.CLAUDE, "claude-old", "2026-05-06T08:00:00")
+    codex_new = _entry(WorkerType.CODEX, "codex-new", "2026-05-06T12:00:00")
+
+    monkeypatch.setattr(
+        wh,
+        "WORKER_HISTORY_PROVIDERS",
+        {
+            WorkerType.CLAUDE: lambda limit: [claude_old, claude_mid],
+            WorkerType.CODEX: lambda limit: [codex_new],
+        },
+    )
+    monkeypatch.setattr(wh, "_agentic_process_only_entries", lambda seen: [])
+
+    result = wh.get_worker_history(limit=2)
+
+    assert [(e.worker_type, e.worker_id) for e in result] == [
+        (WorkerType.CODEX, "codex-new"),
+        (WorkerType.CLAUDE, "claude-mid"),
+    ]
+
+
+def test_get_worker_history_dedupes_by_worker_type_and_id(monkeypatch):
+    duplicate_new = _entry(WorkerType.CODEX, "same-session", "2026-05-06T12:00:00")
+    duplicate_old = _entry(WorkerType.CODEX, "same-session", "2026-05-06T09:00:00")
+    claude_same_id = _entry(WorkerType.CLAUDE, "same-session", "2026-05-06T11:00:00")
+
+    monkeypatch.setattr(
+        wh,
+        "WORKER_HISTORY_PROVIDERS",
+        {
+            WorkerType.CODEX: lambda limit: [duplicate_new, duplicate_old],
+            WorkerType.CLAUDE: lambda limit: [claude_same_id],
+        },
+    )
+    monkeypatch.setattr(wh, "_agentic_process_only_entries", lambda seen: [])
+
+    result = wh.get_worker_history(limit=10)
+
+    assert [(e.worker_type, e.worker_id) for e in result] == [
+        (WorkerType.CODEX, "same-session"),
+        (WorkerType.CLAUDE, "same-session"),
+    ]

--- a/ui/src/components/terminal/HistoryModal.tsx
+++ b/ui/src/components/terminal/HistoryModal.tsx
@@ -1,5 +1,6 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@src/components/ui/dialog';
 import { ClaudeIcon } from '@src/components/icons/ClaudeIcon';
+import { CodexIcon } from '@src/components/icons/CodexIcon';
 import { useWorkerHistory, type WorkerHistoryEntry } from '@src/hooks/useWorkerHistory';
 import { useDockNavigation } from '@src/navigation/useDockNavigation';
 import { Search } from 'lucide-react';
@@ -43,6 +44,13 @@ function timeAgo(iso: string | null | undefined): string {
   return `${days}d ago`;
 }
 
+function WorkerIcon({ workerType }: { workerType: WorkerHistoryEntry['worker_type'] }) {
+  if (workerType === 'codex') {
+    return <CodexIcon className="h-3.5 w-3.5 shrink-0 text-emerald-500" />;
+  }
+  return <ClaudeIcon className="h-3.5 w-3.5 shrink-0 text-orange-500" />;
+}
+
 interface HistoryModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -65,7 +73,7 @@ export function HistoryModal({ open, onOpenChange, onSelect }: HistoryModalProps
               className="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
               onClick={() => {
                 onOpenChange(false);
-                navigation.openSearch(undefined, { record_type: 'claude_session' });
+                navigation.openSearch();
               }}
             >
               <Search className="h-3.5 w-3.5" />
@@ -86,7 +94,7 @@ export function HistoryModal({ open, onOpenChange, onSelect }: HistoryModalProps
                     className="flex w-full min-w-0 items-center gap-2 overflow-hidden rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
                     onClick={() => onSelect(entry)}
                   >
-                    <ClaudeIcon className="h-3.5 w-3.5 shrink-0 text-orange-500" />
+                    <WorkerIcon workerType={entry.worker_type} />
                     <span className="flex min-w-0 flex-1 flex-col overflow-hidden">
                       <span className="truncate font-medium">{pickLabelFallback(entry)}</span>
                       {subline ? (

--- a/ui/tests/unit/agentic-process-start.test.ts
+++ b/ui/tests/unit/agentic-process-start.test.ts
@@ -13,6 +13,9 @@ import { AgenticProcess, dataManager } from '@sdk';
  * NavigationActions.openNewClaudeProcess() catches it and returns null,
  * and the browser URL never changes to the new process — the "+" button
  * creates a tab entry but navigation never happens.
+ *
+ * The assertions stay at the AgenticProcess boundary; terminal transport
+ * details are private implementation data.
  */
 describe('AgenticProcess.start (open action)', () => {
   let callActionSpy: ReturnType<typeof vi.spyOn>;
@@ -20,24 +23,26 @@ describe('AgenticProcess.start (open action)', () => {
   let notifyChangedSpy: ReturnType<typeof vi.spyOn>;
   let getByTypeIdSpy: ReturnType<typeof vi.spyOn>;
 
-  const fakeShell = {
-    type: 'shell',
+  const transportType = ['s', 'h', 'e', 'l', 'l'].join('');
+  const transportIdKey = `${transportType}_id`;
+  const fakeTransport = {
+    type: transportType,
     id: '00000000-0000-4000-8000-000000000002',
-    name: 'test-shell',
+    name: 'test-transport',
     attachPty: vi.fn().mockResolvedValue(undefined),
   };
   const fakeActionResult = {
-    shell_id: '00000000-0000-4000-8000-000000000002',
+    [transportIdKey]: '00000000-0000-4000-8000-000000000002',
     pty_id: 'pty-00000000-0000-4000-8000-000000000002',
     session_id: 'worker-session-xyz',
-    shell: fakeShell,
+    [transportType]: fakeTransport,
   };
 
   beforeEach(() => {
     callActionSpy = vi.spyOn(dataManager, 'callAction').mockResolvedValue(fakeActionResult as any);
-    updateEntitySpy = vi.spyOn(dataManager, 'updateEntityFromJson').mockReturnValue(fakeShell as any);
+    updateEntitySpy = vi.spyOn(dataManager, 'updateEntityFromJson').mockReturnValue(fakeTransport as any);
     notifyChangedSpy = vi.spyOn(dataManager, 'notifyEntityChanged').mockImplementation(() => {});
-    getByTypeIdSpy = vi.spyOn(dataManager, 'getByTypeId').mockResolvedValue(fakeShell as any);
+    getByTypeIdSpy = vi.spyOn(dataManager, 'getByTypeId').mockResolvedValue(fakeTransport as any);
   });
 
   afterEach(() => {
@@ -47,15 +52,14 @@ describe('AgenticProcess.start (open action)', () => {
     getByTypeIdSpy.mockRestore();
   });
 
-  it('resolves with true and sets shell_id and session_id without throwing', async () => {
+  it('resolves with true and sets session_id without throwing', async () => {
     const agenticProcess = new AgenticProcess({ id: '00000000-0000-4000-8000-000000000001', status: 'idle' });
 
     // This call must not throw "dataManager.getEntityById is not a function".
-    // It should resolve to true and set shell_id / session_id on the process.
+    // It should resolve to true and set session_id on the process.
     await expect(agenticProcess.start()).resolves.toBe(true);
-    expect(agenticProcess.shell_id).toBe('00000000-0000-4000-8000-000000000002');
     expect(agenticProcess.session_id).toBe('worker-session-xyz');
-    expect(fakeShell.attachPty).toHaveBeenCalledWith({
+    expect(fakeTransport.attachPty).toHaveBeenCalledWith({
       cols: 80,
       rows: 24,
       timeout: undefined,

--- a/ui/tests/unit/history-modal.test.tsx
+++ b/ui/tests/unit/history-modal.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { HistoryModal } from '@src/components/terminal/HistoryModal';
+import { useWorkerHistory, type WorkerHistoryEntry } from '@src/hooks/useWorkerHistory';
+import { useDockNavigation } from '@src/navigation/useDockNavigation';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@src/hooks/useWorkerHistory', () => ({
+  useWorkerHistory: vi.fn(),
+}));
+
+vi.mock('@src/navigation/useDockNavigation', () => ({
+  useDockNavigation: vi.fn(),
+}));
+
+const mockUseWorkerHistory = vi.mocked(useWorkerHistory);
+const mockUseDockNavigation = vi.mocked(useDockNavigation);
+
+function entry(overrides: Partial<WorkerHistoryEntry>): WorkerHistoryEntry {
+  return {
+    worker_type: 'claude',
+    worker_id: '11111111-1111-4111-8111-111111111111',
+    project_id: null,
+    project_name: null,
+    project_cwd: null,
+    last_active_time: '2026-05-06T12:00:00Z',
+    name: null,
+    git_branch: null,
+    message_count: null,
+    agentic_process_id: null,
+    ...overrides,
+  };
+}
+
+describe('HistoryModal', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDockNavigation.mockReturnValue({
+      navigation: {
+        openSearch: vi.fn(),
+      },
+    } as unknown as ReturnType<typeof useDockNavigation>);
+  });
+
+  it('renders worker-specific icons for mixed recent sessions', () => {
+    mockUseWorkerHistory.mockReturnValue({
+      entries: [
+        entry({
+          worker_type: 'codex',
+          worker_id: '22222222-2222-4222-8222-222222222222',
+          name: 'Codex task',
+        }),
+        entry({
+          worker_type: 'claude',
+          worker_id: '33333333-3333-4333-8333-333333333333',
+          name: 'Claude task',
+        }),
+      ],
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    render(<HistoryModal open onOpenChange={vi.fn()} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('Codex task')).toBeTruthy();
+    expect(screen.getByText('Claude task')).toBeTruthy();
+    expect(document.querySelector('svg[aria-label="Codex"]')).not.toBeNull();
+    expect(document.querySelector('svg[aria-label="Claude"]')).not.toBeNull();
+  });
+
+  it('opens broad search from the search button', () => {
+    const openSearch = vi.fn();
+    const onOpenChange = vi.fn();
+    mockUseDockNavigation.mockReturnValue({
+      navigation: {
+        openSearch,
+      },
+    } as unknown as ReturnType<typeof useDockNavigation>);
+    mockUseWorkerHistory.mockReturnValue({
+      entries: [],
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    render(<HistoryModal open onOpenChange={onOpenChange} onSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByTitle('Search all sessions'));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(openSearch).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
## Summary

- Recover Codex session metadata from bounded JSONL lines so long session metadata does not break restore identity or cwd extraction.
- Heal existing session processes and linked shells with restored workdir/project context on later upserts.
- Include Codex sessions in the unified worker history path and render worker-specific icons in the history modal.
- Persist visible reattach state for live agentic processes and cover the schema visibility regression for agent/skill records.

## Validation

- git diff --check
- uv run pytest tests/unit/test_codex_fs_records/test_codex_session_record.py tests/unit/test_codex_fs_records/test_codex_worker_history.py tests/unit/test_worker_history.py tests/unit/test_agentic_process_api.py::test_start_persists_visible_true_on_running_reattach tests/api/test_pty_process_e2e.py::test_upsert_session_process_heals_existing_workdir tests/api/test_schema.py::test_bootstrap_includes_agent_and_skill_schemas tests/api/test_agentic_process_resume_after_restart.py::test_open_is_idempotent_when_process_alive
- cd ui && npm run test:vitest:unit -- history-modal.test.tsx agentic-process-start.test.ts