### PR TITLE
Widen Electron cold-start health-check window to 90s

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -168,7 +168,7 @@ const BACKEND_PORT = 9007;
 const BACKEND_URL = `http://localhost:${BACKEND_PORT}`;
 const FLOWPAD_CLOUD_URL = process.env.FLOWPAD_CLOUD_URL || 'https://app.flowpad.ai';
 const HEALTH_CHECK_INTERVAL = 500; // ms
-const MAX_HEALTH_CHECKS = 60; // 30 seconds — used for cold-start
+const MAX_HEALTH_CHECKS = 180; // 90 seconds — cold-start window
 const POST_UPGRADE_HEALTH_CHECKS = 240; // 120 seconds — matches uv upgrade() ceiling
 
 let mainWindow = null;


### PR DESCRIPTION
## Summary
Widens the Electron cold-start backend health-check window from 30s to 90s to prevent spurious "Backend failed to start within timeout." failures.

On Windows, AV scanning the bundled Python exe on the first launch of the day routinely pushes backend boot past the old 30s budget. The post-upgrade path already allows 120s; this brings cold start up to a more forgiving 90s.

## Change
- `electron/main.js`: `MAX_HEALTH_CHECKS` 60 → 180 (30s → 90s, at the 500ms interval).

## Test plan
- [ ] Cold launch on a Windows machine with AV active; confirm backend comes up without the timeout error.
- [ ] Normal/warm launch still starts promptly (no regression in perceived startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)