### PR TITLE
FLOWPAD-1887: Conv and diag bugs

### DIFF
--- a/flow_sdk/app/actions/diagnose_action.py
+++ b/flow_sdk/app/actions/diagnose_action.py
@@ -63,9 +63,12 @@ async def diagnose() -> StreamingResponse:
                 message,
                 DEFAULT_TRANSCRIPT_TIMEOUT_S,
                 emit=emit,
-                # Post a Home-Feed card ONLY if the modal is already gone by the time
-                # the diagnosis is recorded — otherwise the modal surfaces it itself.
-                create_feed_entry=lambda: not watching["v"],
+                # Post a Home-Feed card ONLY if the modal is already gone by the time the
+                # diagnosis is recorded — otherwise the modal surfaces it itself. When it
+                # IS gone, post for any result (has_issue ignored): an issue card with the
+                # report buttons, or a no-issue card carrying the summary, so a user who
+                # walked away still gets the answer.
+                create_feed_entry=lambda has_issue: not watching["v"],
             )
         except Exception as e:  # surface the failure into the stream, never 500 silently
             emit({"type": "error", "text": f"diagnose error: {e}"})
@@ -120,22 +123,25 @@ async def diagnose_post_feed() -> ApiResponse:
 
     The UI calls this when the diagnose modal finished while the user wasn't watching
     (app minimized, tab backgrounded, another window/app focused): the stream stayed
-    connected, so the run didn't post a card itself, yet the in-modal report buttons
-    were never seen. This re-posts that card so they stay reachable from the Home Feed.
-    The complementary modal-closed case is handled inline by the streaming run, so the
-    two never both fire for one run. Body: ``{diagnosis_id?, conversation_id,
-    flow_message_id}`` — the ids the stream's ``done`` event already carried.
+    connected, so the run didn't post a card itself, yet the result was never seen. This
+    posts the card so the answer reaches the Home Feed — an issue card with the report
+    buttons (``conversation_id`` + ``flow_message_id`` given) or, for a clean result, a
+    no-issue card carrying the summary. The complementary modal-closed case is handled
+    inline by the streaming run, so the two never both fire for one run. Body:
+    ``{diagnosis_id, conversation_id?, flow_message_id?}`` — the ids the stream's
+    ``done`` event carried (conversation/message only exist for an issue).
     """
     request_info = get_current_request_info()
     body = (await request_info.get_post_data() if request_info else None) or {}
     conv_id = body.get("conversation_id")
     msg_id = body.get("flow_message_id")
-    if not conv_id or not msg_id:
+    diag_id = body.get("diagnosis_id")
+    # Need either a diagnosis (to read its summary) or a support conversation to post.
+    if not diag_id and not (conv_id and msg_id):
         return ApiSuccessResponse(data={"feed_entry_id": None})
 
     # message_text is the diagnosis summary — load it the same way the CLI runner does.
     summary = ""
-    diag_id = body.get("diagnosis_id")
     if diag_id:
         from flow_sdk.fs_store.schema_registry import SchemaRegistry
         from flow_sdk.schema.types import EntityType
@@ -145,6 +151,6 @@ async def diagnose_post_feed() -> ApiResponse:
         summary = (getattr(diag, "summary", None) or getattr(diag, "title", None) or "") if diag else ""
 
     feed_entry_id = await _post_home_feed_entry(
-        conversation_id=conv_id, flow_message_id=msg_id, summary=summary
+        summary=summary, conversation_id=conv_id, flow_message_id=msg_id
     )
     return ApiSuccessResponse(data={"feed_entry_id": feed_entry_id})

--- a/flow_sdk/app/actions/execute_prompt.py
+++ b/flow_sdk/app/actions/execute_prompt.py
@@ -75,11 +75,19 @@ async def build_merged_prompt(fm: "FlowMessage") -> str:
     from flow_sdk.builtin.prompt import Prompt
 
     # Pull the body bundle once so file-backed attachments resolve to disk.
+    # Best-effort, but NOT silent: a failure here (e.g. body_status still
+    # UPLOADING) is exactly what strands an attachment with an unreadable
+    # relative VFS path, so surface it. The bridge now gates auto-run on
+    # body_status=READY (see hub_bridge ``_handle_flow_message_op``), so this
+    # should only fail on the manual-Execute edge.
     try:
         if fm.has_body():
             await fm.download_body()
-    except Exception:
-        pass  # best-effort — fall back to inline previews / raw paths
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "[execute_prompt] body download failed for fm=%s — attachments may "
+            "not resolve to absolute paths: %s", fm.id, e,
+        )
 
     inline_parts: list[str] = []
     prompt_file_lines: list[str] = []

--- a/flow_sdk/builtin/feed_entry.py
+++ b/flow_sdk/builtin/feed_entry.py
@@ -35,15 +35,19 @@ class FeedKind(StrEnum):
 class MessageSuggest(BaseModel):
     """Payload (the ``T``) for a FeedEntry of kind ``message_suggest``.
 
-    Carries the user-facing header ``text`` plus a pointer to the (until-then
-    hidden) support ``Conversation`` and its summary ``FlowMessage`` so the Feed
-    card can render the summary without an extra fetch.
+    Carries the user-facing header ``text`` and the diagnosis summary
+    (``message_text``) so the Feed card renders without an extra fetch. For a real
+    *issue* it also points at the (until-then hidden) support ``Conversation`` and
+    its summary ``FlowMessage`` — those drive the Report / Forward actions. A
+    *no-issue* card (posted only when the user wasn't watching the diagnose modal,
+    so they still get the answer) has no conversation: ``conversation_id`` /
+    ``flow_message_id`` are absent and the card shows just the summary + Dismiss.
     """
 
     text: str
-    conversation_id: str
-    flow_message_id: str
     message_text: str
+    conversation_id: Optional[str] = None
+    flow_message_id: Optional[str] = None
 
 
 class FeedEntry(Entity):

--- a/flow_sdk/cli/commands/diagnose_cmd.py
+++ b/flow_sdk/cli/commands/diagnose_cmd.py
@@ -146,14 +146,21 @@ class _Renderer:
         self._emit({"type": "flush"})
 
 
-async def _post_home_feed_entry(*, conversation_id: str, flow_message_id: str, summary: str) -> str | None:
+async def _post_home_feed_entry(
+    *, summary: str, conversation_id: str | None = None, flow_message_id: str | None = None
+) -> str | None:
     """Post the Home-Feed ``message_suggest`` card for a recorded diagnosis, SDK-direct.
 
-    This is the CLI surface's job — ``report.py`` only records the diagnosis and its
-    support Conversation/FlowMessage. We create the ``FeedEntry`` here (in the runner's
-    own process, which is bootstrapped and works even when the backend is down), so the
-    UI surface — which calls ``_run_diagnose`` with ``create_feed_entry=False`` — never
-    gets a feed card; it reuses the same Conversation/FlowMessage in its own modal.
+    The single creator both surfaces use (the CLI runner, and the UI's
+    ``diagnose_post_feed`` action). We create the ``FeedEntry`` here — in a process that
+    is bootstrapped and works even when the backend is down.
+
+    Two shapes, keyed on whether there's a support conversation:
+
+    * **Issue** (``conversation_id`` + ``flow_message_id`` given) — the card points at
+      the hidden support Conversation/FlowMessage so it can offer Report / Forward.
+    * **No issue** (neither given) — there's nothing to report, but the card still
+      carries the summary so a user who wasn't watching the modal still gets the answer.
 
     Returns the new entry id, or ``None`` on failure (best-effort; never fails the run).
     """
@@ -162,11 +169,17 @@ async def _post_home_feed_entry(*, conversation_id: str, flow_message_id: str, s
         from flow_sdk.server.routes.bootstrap import get_or_create_local_user
 
         user = await get_or_create_local_user()
+        has_issue = bool(conversation_id and flow_message_id)
+        header = (
+            "An error came up while using Flowpad — here's what the diagnostic found:"
+            if has_issue
+            else "Flowpad diagnostic finished — here's what we found:"
+        )
         suggest = MessageSuggest(
-            text="An error came up while using Flowpad — here's what the diagnostic found:",
+            text=header,
+            message_text=(summary or "").strip(),
             conversation_id=conversation_id,
             flow_message_id=flow_message_id,
-            message_text=(summary or "").strip(),
         )
         feed = FeedEntry(
             kind=FeedKind.MESSAGE_SUGGEST.value,
@@ -184,7 +197,7 @@ async def _run_diagnose(
     transcript_timeout: float,
     *,
     emit=None,
-    create_feed_entry: "bool | Callable[[], bool]" = True,
+    create_feed_entry: "bool | Callable[[bool], bool]" = True,
 ) -> int:
     """Run the flow-diagnose skill headless and stream the worker's narration.
 
@@ -193,17 +206,23 @@ async def _run_diagnose(
     ``_TerminalSink`` so the CLI renders exactly as before; the UI's HTTP endpoint
     passes its own ``emit`` to forward the same events as SSE.
 
-    ``create_feed_entry`` decides whether to post the Home-Feed card for a real issue.
-    It may be a bool or a zero-arg callable evaluated at posting time (so a late
-    decision — e.g. "did the UI modal close before we finished?" — is possible). The
-    CLI passes ``True`` (the Feed card is the CLI's user-facing output). The UI action
-    passes a callable that returns ``True`` only when its modal is already gone: while
-    the modal is open it shows the report buttons itself, so no card is posted; if the
-    user defocused and the popup vanished mid-run, the card is posted so those same
-    buttons stay reachable from the Home Feed. report.py is identical for both
-    surfaces: it always records the diagnosis and (for an issue) its support
-    Conversation/FlowMessage; only this Feed posting differs, so the split is fully
-    deterministic and never relies on the worker.
+    ``create_feed_entry`` decides whether to post the Home-Feed card. It is given the
+    run's ``has_issue`` and returns whether to post; it may also be a bool, where
+    ``True`` means "post for an issue only" (the no-issue card needs an explicit
+    callable). A callable is evaluated at posting time, so a late decision — "did the
+    UI modal close / go unwatched before we finished?" — is possible.
+
+    * **CLI** passes ``True``: post a card for an issue (its Report/Forward actions are
+      the CLI's lasting output); a clean sweep prints to the terminal, no card.
+    * **UI** passes ``lambda has_issue: <user wasn't watching>``: while the modal is
+      open and focused it shows the result itself, so nothing is posted; if the user
+      defocused / minimized, a card is posted **for any result** — an issue card with
+      the report buttons, or a no-issue card carrying the summary so they still get
+      the answer.
+
+    report.py is identical for both surfaces: it always records the diagnosis and (for
+    an issue) its support Conversation/FlowMessage; only this Feed posting differs, so
+    the split is fully deterministic and never relies on the worker.
     """
     if emit is None:
         emit = _TerminalSink()
@@ -404,15 +423,21 @@ async def _run_diagnose(
                         await cross_link_entities(fresh, diag)
             except Exception:
                 pass
-            # Post the Home-Feed card for a real issue. The CLI always does (its only
-            # output); the UI does ONLY if its modal closed before we finished (evaluated
-            # now, via the callable), otherwise the modal shows the buttons itself.
-            want_feed = create_feed_entry() if callable(create_feed_entry) else create_feed_entry
+            # Post the Home-Feed card. has_issue ⇔ report.py created a support
+            # Conversation/FlowMessage. A bool create_feed_entry posts for an issue only
+            # (CLI); a callable gets has_issue and may also post a no-issue summary card
+            # (UI, when the user wasn't watching). Evaluated now so the decision can read
+            # live state (e.g. whether the modal is still connected).
+            has_issue = bool(conv_id and msg_id)
+            if callable(create_feed_entry):
+                want_feed = create_feed_entry(has_issue)
+            else:
+                want_feed = bool(create_feed_entry) and has_issue
             feed_entry_id = None
-            if want_feed and conv_id and msg_id:
+            if want_feed:
                 summary = (getattr(diag, "summary", None) or getattr(diag, "title", None) or "") if diag else ""
                 feed_entry_id = await _post_home_feed_entry(
-                    conversation_id=conv_id, flow_message_id=msg_id, summary=summary
+                    summary=summary, conversation_id=conv_id, flow_message_id=msg_id
                 )
             emit({"type": "status", "text": "  ✓ Diagnostic complete — diagnosis recorded."})
             emit({

--- a/flow_sdk/cloud_client/hub_bridge.py
+++ b/flow_sdk/cloud_client/hub_bridge.py
@@ -69,6 +69,35 @@ def _has_asset_typeid_attachment(attachments: Any) -> bool:
     return False
 
 
+def _has_prompt_attachment(attachments: Any) -> bool:
+    """True iff ``attachments`` includes a runnable prompt — a legacy inline/file
+    PROMPT attachment or a ``prompt-<id>`` TYPE_ID reference.
+
+    Tolerates both the hub wire shape (list of dicts) and the local model shape
+    (list of ``Attachment`` instances) — ``attachment_type`` is a str-Enum that
+    compares equal to its value either way. Single source for the bridge's
+    "is there a prompt to auto-run?" pre-check, shared by the CREATE-time trigger
+    and the body-READY re-trigger.
+    """
+    if not attachments:
+        return False
+    for att in attachments:
+        att_type = (
+            att.get("attachment_type") if isinstance(att, dict)
+            else getattr(att, "attachment_type", None)
+        )
+        if att_type == "prompt":
+            return True
+        if att_type == "type_id":
+            data = (
+                att.get("data") if isinstance(att, dict)
+                else getattr(att, "data", None)
+            )
+            if isinstance(data, str) and data.split("-", 1)[0] == "prompt":
+                return True
+    return False
+
+
 # In-flight bundle pulls keyed by fm_id — guards against the bridge
 # scheduling two concurrent downloads for the same FM (CREATE-with-READY
 # arriving before the UPDATE-to-READY, or two UPDATEs in quick succession).
@@ -477,16 +506,25 @@ class HubWsBridge:
                     # payload so a plain text message never spawns the task (and its
                     # DB fetch). Detached so a slow/failed run never blocks persist
                     # or the auto-ack below; failure-isolated inside the hook.
-                    if any(
-                        isinstance(a, dict) and (
-                            a.get("attachment_type") == "prompt"
-                            or (a.get("attachment_type") == "type_id"
-                                and str(a.get("data") or "").split("-", 1)[0] == "prompt")
-                        )
-                        for a in (payload.get("attachment") or [])
-                    ):
-                        from flow_sdk.app.actions.execute_prompt import process_inbound_message
-                        asyncio.create_task(process_inbound_message(fm_id, conversation_id))
+                    #
+                    # But a body-bearing prompt (image/file attached) must NOT run
+                    # while its body is still UPLOADING on the hub: build_merged_prompt
+                    # downloads the body to resolve each attachment to an absolute
+                    # on-disk path, and download_body refuses until body_status=READY —
+                    # so running now would strand the prompt with an unreadable
+                    # relative VFS path (e.g. ``prompt/image.png``). Defer to the
+                    # body_status→READY UPDATE below, which re-fires this hook; the
+                    # ``prompt_auto_handled`` marker keeps the two trigger points
+                    # idempotent (only one run executes).
+                    if _has_prompt_attachment(payload.get("attachment")):
+                        if payload.get("body_status") == "uploading":
+                            logger.info(
+                                "[bridge] prompt body still uploading — deferring "
+                                "auto-run until READY fm=%s", fm_id,
+                            )
+                        else:
+                            from flow_sdk.app.actions.execute_prompt import process_inbound_message
+                            asyncio.create_task(process_inbound_message(fm_id, conversation_id))
                 except Exception as _err:
                     logger.warning(
                         "[bridge] inbound persist failed fm=%s (non-fatal): %s", fm_id, _err,
@@ -586,6 +624,17 @@ class HubWsBridge:
                     getattr(existing, "attachment", None) or [],
                     body_status=new_body_status,
                 ))
+                # A body-bearing prompt whose auto-run was deferred at CREATE (the
+                # body was still UPLOADING) runs now that body_status=READY —
+                # build_merged_prompt can download the body and resolve every
+                # attachment to an absolute path. Idempotent via prompt_auto_handled
+                # (and re-checked inside the hook: drafts, our own sends, missing
+                # permission all no-op), so this is safe for prompts already run or
+                # never ours to run.
+                conv_id = parent_conv_id or getattr(existing, "conversation_id", None)
+                if conv_id and _has_prompt_attachment(getattr(existing, "attachment", None)):
+                    from flow_sdk.app.actions.execute_prompt import process_inbound_message
+                    asyncio.create_task(process_inbound_message(fm_id, conv_id))
             return
 
         if op == "delete":

--- a/flow_sdk/system_projects/flowpad_assistant/.claude/skills/flowpad-assistance/search.md
+++ b/flow_sdk/system_projects/flowpad_assistant/.claude/skills/flowpad-assistance/search.md
@@ -78,6 +78,28 @@ Success — exit 0, single JSON line:
 
 If the user mentions a type (*"any tasks I touched today"*), filter the results yourself by `record_type == "task"` after the call returns. Don't try to pass type filters through this CLI — only `query`, `time`, and `limit` are wired.
 
+### Listing entities by an exact field value (e.g. "running processes")
+
+FTS search above is text-only — it can't answer *"list the agentic_processes whose `status` is `running`"*. When you need an **exact field match** on a typed list, query the graph API for that type and let the indexer's stored fields do the matching. **Do not hand-build a `key:value` filter string** — the backend parses `filter` with `json.loads`, so the param MUST be a JSON object:
+
+```bash
+# Correct — filter is a JSON object, URL-encoded:
+flow record search   # ← preferred whenever a text query suffices; only drop to the API for exact field lists.
+
+# When you genuinely need an exact field list, the graph GET's filter is JSON:
+#   filter={"match":{"status":"running"}}
+curl -sG "http://127.0.0.1:$PORT/api/v1/graph/agentic_process" \
+  --data-urlencode 'limit=10' \
+  --data-urlencode 'filter={"match":{"status":"running"}}'
+```
+
+| | `filter` value | Result |
+| --- | --- | --- |
+| ✅ Correct | `{"match":{"status":"running"}}` | matches `status == "running"` |
+| ❌ Wrong | `status:running` | **500** — `Invalid query filter JSON: Expecting value: line 1 column 1` |
+
+`--data-urlencode` is what keeps the JSON braces/quotes intact on the wire. Resolve `$PORT` from your instance's `server.json` (or `flow context`); never hardcode it. This is the one read-only exception to *"never call backend APIs directly"* — it mutates nothing.
+
 ### Disambiguating
 
 When several rows have the same `name` (common for things named after files, e.g. `electron.md`), use `asset_ref` to disambiguate to the user. Don't navigate without confirmation when the user's phrasing is ambiguous.

--- a/tests/cli/test_diagnose_cmd.py
+++ b/tests/cli/test_diagnose_cmd.py
@@ -434,22 +434,53 @@ async def test_post_home_feed_entry_makes_a_real_card_appear():
     assert entry.feed_data["message_text"] == "Cleared a stale server.lock; the backend starts now."
 
 
+@pytest.mark.asyncio
+async def test_post_home_feed_entry_no_issue_card_has_summary_no_conversation():
+    """The no-issue variant of the creator (posted when the user wasn't watching, so
+    they still get an answer): a `new`/`message_suggest` card carrying the summary as
+    its body, a non-error header, and NO conversation — nothing to report/forward."""
+    from flow_sdk.builtin.feed_entry import FeedEntry, FeedKind, FeedStatus
+    from flow_sdk.cli.commands.diagnose_cmd import _post_home_feed_entry
+
+    await _bootstrap_local_user()
+    fid = await _post_home_feed_entry(summary="All healthy — typing works; nothing to fix.")
+    assert fid
+
+    entry = await FeedEntry.get_by_id(fid)
+    assert entry is not None
+    assert entry.kind == FeedKind.MESSAGE_SUGGEST.value
+    assert entry.feed_status == FeedStatus.NEW.value
+    assert entry.feed_data["message_text"] == "All healthy — typing works; nothing to fix."
+    assert not entry.feed_data.get("conversation_id")  # no issue → no support conversation
+    assert not entry.feed_data.get("flow_message_id")
+    assert "error came up" not in entry.feed_data["text"]  # not the issue header
+
+
 @pytest.mark.parametrize(
-    "label,create_feed_entry,expect_card",
+    "label,create_feed_entry,has_issue,expect_card,expect_conversation",
     [
-        ("cli_always_posts", True, True),               # CLI surface: the card IS the output
-        ("ui_user_not_watching", lambda: True, True),   # UI: modal gone / app hidden → post
-        ("ui_user_watching", lambda: False, False),     # UI: user saw the buttons → no card
+        # CLI (bool True) posts for an issue only; a clean sweep prints to the terminal.
+        ("cli_issue", True, True, True, True),
+        ("cli_no_issue", True, False, False, False),
+        # UI 'user not watching' callable posts for ANY result — issue card or summary card.
+        ("ui_unwatched_issue", lambda h: True, True, True, True),
+        ("ui_unwatched_no_issue", lambda h: True, False, True, False),  # the new behavior
+        # UI 'user watching' callable never posts — the modal shows the result itself.
+        ("ui_watching_issue", lambda h: False, True, False, False),
+        ("ui_watching_no_issue", lambda h: False, False, False, False),
     ],
 )
 @pytest.mark.asyncio
-async def test_feed_card_appears_per_watching_logic(label, create_feed_entry, expect_card):
+async def test_feed_card_appears_per_watching_logic(
+    label, create_feed_entry, has_issue, expect_card, expect_conversation
+):
     """End-to-end at the runner layer: `create_feed_entry` is the on/off switch for
-    whether a real Home-Feed card appears for a recorded issue. Both directions are
-    demonstrated — flip it on (CLI `True`, or the UI 'not watching' callable → True)
-    and a queryable FeedEntry appears; flip it off (UI 'watching' callable → False)
-    and none does. `_post_home_feed_entry` is NOT mocked, so the card's existence is
-    proven by loading it back from the store."""
+    whether a real Home-Feed card appears. Both directions are demonstrated across the
+    matrix — CLI posts for an issue only; the UI 'not watching' callable posts for ANY
+    result (including a no-issue summary card, so a user who walked away still gets an
+    answer); the UI 'watching' callable never posts. `_post_home_feed_entry` is NOT
+    mocked, so the card's existence (and whether it carries a conversation) is proven by
+    loading it back from the store."""
     import tempfile
     import uuid
     from pathlib import Path
@@ -459,11 +490,19 @@ async def test_feed_card_appears_per_watching_logic(label, create_feed_entry, ex
     from flow_sdk.cli.commands import diagnose_cmd
 
     await _bootstrap_local_user()
-    conv_id, msg_id, diag_id = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
-    report_json = (
-        f'{{"diagnosis_id": "{diag_id}", "conversation_id": "{conv_id}", '
-        f'"flow_message_id": "{msg_id}", "has_issue": true}}'
-    )
+    diag_id = str(uuid.uuid4())
+    if has_issue:
+        conv_id, msg_id = str(uuid.uuid4()), str(uuid.uuid4())
+        report_json = (
+            f'{{"diagnosis_id": "{diag_id}", "conversation_id": "{conv_id}", '
+            f'"flow_message_id": "{msg_id}", "has_issue": true}}'
+        )
+    else:
+        conv_id = msg_id = None
+        report_json = (
+            f'{{"diagnosis_id": "{diag_id}", "conversation_id": null, '
+            f'"flow_message_id": null, "has_issue": false}}'
+        )
 
     _tf = tempfile.NamedTemporaryFile(prefix="diag_card_", suffix=".jsonl", delete=False)
     _tf.write(b'{"type":"system"}\n')
@@ -488,8 +527,8 @@ async def test_feed_card_appears_per_watching_logic(label, create_feed_entry, ex
             return None
 
         async def stream_transcript(self, timeout=0):
-            # A real issue: report.py prints conversation + message ids, then the
-            # stream ends cleanly so the feed-decision runs immediately.
+            # report.py prints its result JSON, then the stream ends cleanly so the
+            # feed-decision runs immediately.
             yield {
                 "message": {
                     "role": "user",
@@ -532,7 +571,11 @@ async def test_feed_card_appears_per_watching_logic(label, create_feed_entry, ex
         assert entry is not None, "the posted card must actually exist in the store"
         assert entry.kind == FeedKind.MESSAGE_SUGGEST.value
         assert entry.feed_status == FeedStatus.NEW.value
-        assert entry.feed_data["conversation_id"] == conv_id
-        assert entry.feed_data["flow_message_id"] == msg_id
+        if expect_conversation:
+            assert entry.feed_data["conversation_id"] == conv_id
+            assert entry.feed_data["flow_message_id"] == msg_id
+        else:
+            assert not entry.feed_data.get("conversation_id")  # no-issue summary card
+            assert not entry.feed_data.get("flow_message_id")
     else:
-        assert done["feed_entry_id"] is None, "no card must be posted while the user is watching"
+        assert done["feed_entry_id"] is None, "no card must be posted in this case"

--- a/tests/unit/test_hub_bridge_prompt_gate.py
+++ b/tests/unit/test_hub_bridge_prompt_gate.py
@@ -1,0 +1,43 @@
+"""Unit tests for the bridge's prompt auto-run discriminator.
+
+``_has_prompt_attachment`` is the pre-check the hub bridge uses to decide
+whether an inbound FlowMessage carries a runnable prompt — and, paired with
+``body_status``, whether to auto-run it now or defer until the body is READY
+(the fix for the ``prompt/image.png`` relative-path bug). It must agree on both
+the hub wire shape (list of dicts) and the local model shape (Attachment
+instances).
+"""
+from flow_sdk.builtin.flow_message import Attachment, AttachmentType
+from flow_sdk.cloud_client.hub_bridge import _has_prompt_attachment
+
+
+def test_inline_or_file_prompt_attachment_dict():
+    assert _has_prompt_attachment([{"attachment_type": "prompt", "data": "prompt/image.png"}])
+    assert _has_prompt_attachment([{"attachment_type": "prompt", "data": "do the thing"}])
+
+
+def test_prompt_typeid_attachment_dict():
+    assert _has_prompt_attachment([
+        {"attachment_type": "type_id", "data": "prompt-98c2a74c-2f5f-4d2d-b090-e2df1d8184f1"},
+    ])
+
+
+def test_local_attachment_model_shape():
+    atts = [
+        Attachment(attachment_type=AttachmentType.TYPE_ID, data="conversation-abc"),
+        Attachment(attachment_type=AttachmentType.PROMPT, data="prompt/photo.jpeg"),
+    ]
+    assert _has_prompt_attachment(atts)
+
+
+def test_no_prompt_attachment():
+    assert not _has_prompt_attachment(None)
+    assert not _has_prompt_attachment([])
+    assert not _has_prompt_attachment([
+        {"attachment_type": "type_id", "data": "conversation-abc"},
+        {"attachment_type": "file", "data": "data/report.pdf"},
+    ])
+    # A non-prompt TYPE_ID whose id happens to contain a dash must not match.
+    assert not _has_prompt_attachment([
+        {"attachment_type": "type_id", "data": "markdown-1234-5678"},
+    ])

--- a/ts_sdk/src/entities/feed-entry.ts
+++ b/ts_sdk/src/entities/feed-entry.ts
@@ -5,16 +5,18 @@ export type FeedStatus = 'new' | 'dismissed' | 'expired';
 export type FeedKind = 'message_suggest';
 
 /** Payload (the `T`) for a FeedEntry of kind `message_suggest`. Mirrors the
- *  backend `MessageSuggest`. */
+ *  backend `MessageSuggest`. An *issue* card carries the support conversation
+ *  (enabling Report/Forward); a *no-issue* card (posted when the user wasn't
+ *  watching the diagnose modal) omits it and just shows the summary. */
 export interface IMessageSuggest {
   /** User-facing header line. */
   text: string;
-  /** The (until-then hidden) support conversation this entry points at. */
-  conversation_id: string;
-  /** The summary FlowMessage in that conversation. */
-  flow_message_id: string;
   /** Summary body, so the card renders without a follow-up fetch. */
   message_text: string;
+  /** The (until-then hidden) support conversation this entry points at — issue only. */
+  conversation_id?: string;
+  /** The summary FlowMessage in that conversation — issue only. */
+  flow_message_id?: string;
 }
 
 export interface IFeedEntry extends IEntity {

--- a/ui/src/components/version-popover/diagnose-modal.tsx
+++ b/ui/src/components/version-popover/diagnose-modal.tsx
@@ -2,7 +2,7 @@ import { DiagnosisActionButtons } from '@src/components/diagnose/diagnosis-actio
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@src/components/ui/dialog';
 import { Textarea } from '@src/components/ui/textarea';
 import { ActionInfo, dataManager, FlowpadDiagnosis, sendDiagnosisReport } from '@sdk';
-import { CheckCircle2, Loader2, Stethoscope, XCircle } from 'lucide-react';
+import { CheckCircle2, Info, Loader2, Stethoscope, XCircle } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface DiagnoseModalProps {
@@ -276,10 +276,13 @@ export function DiagnoseModal({ open, onClose, onViewDiagnosis }: DiagnoseModalP
           )}
 
           {running && (
-            <p className="text-[11px] text-muted-foreground">
-              This runs in the background — feel free to close this and keep working. When it's
-              done, the result (and any actions) will be waiting on your Home feed.
-            </p>
+            <div className="flex items-start gap-2 rounded-md border border-blue-500/40 bg-blue-500/10 px-2.5 py-2 text-[11px] font-medium text-blue-700 dark:border-blue-400/40 dark:text-blue-300">
+              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                This runs in the background — feel free to close this and keep working. When it's
+                done, the result (and any actions) will be waiting on your Home feed.
+              </span>
+            </div>
           )}
 
           {!started && (

--- a/ui/src/components/version-popover/diagnose-modal.tsx
+++ b/ui/src/components/version-popover/diagnose-modal.tsx
@@ -101,20 +101,16 @@ export function DiagnoseModal({ open, onClose, onViewDiagnosis }: DiagnoseModalP
       });
       // If the diagnosis finished while the user was NOT watching this modal — the
       // app was minimized, this tab was backgrounded, or another window/app held
-      // focus — the in-modal report buttons were never seen. Ask the backend to post
-      // the Home-Feed card (the one creator, `_post_home_feed_entry`) so Report /
-      // Forward / View-diagnosis stay reachable from the Home Feed. The modal-closed
-      // (stream-disconnected) case is handled inline by the run and never reaches
-      // here, so the two paths can't both fire for one run.
+      // focus — the result was never seen. Ask the backend to post the Home-Feed card
+      // (the one creator, `_post_home_feed_entry`) so the answer reaches the feed:
+      // an issue card with Report/Forward, or a no-issue card with the summary. Posting
+      // happens for ANY result here (gated on diagnosis_id, not conversation_id) so a
+      // user who walked away still gets an answer. The modal-closed (stream-
+      // disconnected) case is handled inline by the run and never reaches here, so the
+      // two paths can't both fire for one run.
       const userWatching =
         document.visibilityState === 'visible' && document.hasFocus();
-      if (
-        ev.ok &&
-        ev.conversation_id &&
-        ev.flow_message_id &&
-        !userWatching &&
-        !feedHandoffRef.current
-      ) {
+      if (ev.ok && ev.diagnosis_id && !userWatching && !feedHandoffRef.current) {
         feedHandoffRef.current = true;
         setHandedToFeed(true);
         const info = new ActionInfo('diagnose_post_feed', null, null, 'POST');
@@ -279,6 +275,13 @@ export function DiagnoseModal({ open, onClose, onViewDiagnosis }: DiagnoseModalP
             </div>
           )}
 
+          {running && (
+            <p className="text-[11px] text-muted-foreground">
+              This runs in the background — feel free to close this and keep working. When it's
+              done, the result (and any actions) will be waiting on your Home feed.
+            </p>
+          )}
+
           {!started && (
             <div className="flex justify-end">
               <button
@@ -292,25 +295,25 @@ export function DiagnoseModal({ open, onClose, onViewDiagnosis }: DiagnoseModalP
             </div>
           )}
 
-          {/* On an issue, the same report buttons as a Feed entry — plus "View diagnosis".
-              But if the run finished while the user was away, we posted a Home-Feed card
-              instead; point them there rather than showing a second set of buttons. */}
-          {done?.ok &&
-            done.conversationId &&
-            (handedToFeed ? (
-              <p className="text-[11px] text-muted-foreground">
-                You stepped away while this finished, so it was saved to your Home feed — open it
-                there to report or forward it.
-              </p>
-            ) : (
-              <DiagnosisActionButtons
-                suggestedConversationId={done.conversationId}
-                busy={reporting}
-                error={reportError}
-                onDismiss={handleClose}
-                onReport={(conversationId) => void handleReport(conversationId)}
-              />
-            ))}
+          {/* Finished while the user was away → we posted a Home-Feed card (for any
+              result); point them there instead of showing buttons they didn't see. */}
+          {done?.ok && handedToFeed && (
+            <p className="text-[11px] text-muted-foreground">
+              You stepped away while this finished, so it was saved to your Home feed — open it
+              there{done.conversationId ? ' to report or forward it' : ' to read the result'}.
+            </p>
+          )}
+
+          {/* Watching at the finish, and it's an issue → the Feed-entry report buttons. */}
+          {done?.ok && !handedToFeed && done.conversationId && (
+            <DiagnosisActionButtons
+              suggestedConversationId={done.conversationId}
+              busy={reporting}
+              error={reportError}
+              onDismiss={handleClose}
+              onReport={(conversationId) => void handleReport(conversationId)}
+            />
+          )}
 
           {(done || (started && !running)) && (
             <div className="flex justify-end gap-2">

--- a/ui/src/pages/home-landing/Feed.tsx
+++ b/ui/src/pages/home-landing/Feed.tsx
@@ -166,7 +166,7 @@ export function Feed() {
   if (!newEntries.length) return null;
 
   return (
-    <div className="w-full max-w-3xl flex flex-col gap-2">
+    <div className="w-full max-w-3xl self-center flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain">
       {newEntries.map((entry) => (
         <FeedEntryCard
           key={entry.id}

--- a/ui/src/pages/home-landing/Feed.tsx
+++ b/ui/src/pages/home-landing/Feed.tsx
@@ -2,7 +2,7 @@ import { FeedEntry, QueryRequest } from '@sdk';
 import { DiagnosisActionButtons } from '@src/components/diagnose/diagnosis-action-buttons';
 import { useEntitiesQuery } from '@src/hooks/entity-hooks';
 import { useFeedMutations } from '@src/hooks/use-feed-mutations';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, EyeOff } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 /** Format a feed entry's `created_date` (ISO string or Date) as a local date+time (empty if absent). */
@@ -93,13 +93,30 @@ function FeedEntryCard({ entry, busy, error, onDismiss, onReport }: FeedEntryCar
           </div>
         ))}
 
-      <DiagnosisActionButtons
-        suggestedConversationId={suggest?.conversation_id}
-        busy={busy}
-        error={error}
-        onDismiss={() => onDismiss(entry)}
-        onReport={(conversationId) => onReport(entry, conversationId)}
-      />
+      {suggest?.conversation_id ? (
+        // Issue card: full Report / Forward / Dismiss row pointing at the support conversation.
+        <DiagnosisActionButtons
+          suggestedConversationId={suggest.conversation_id}
+          busy={busy}
+          error={error}
+          onDismiss={() => onDismiss(entry)}
+          onReport={(conversationId) => onReport(entry, conversationId)}
+        />
+      ) : (
+        // No-issue card: nothing to report — the summary above is the answer, so just Dismiss.
+        <div className="mt-2 flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            aria-label="Dismiss"
+            title="Dismiss"
+            disabled={busy}
+            onClick={() => onDismiss(entry)}
+            className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <EyeOff className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -166,7 +183,7 @@ export function Feed() {
   if (!newEntries.length) return null;
 
   return (
-    <div className="w-full max-w-3xl self-center flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain">
+    <div className="w-full max-w-3xl flex max-h-[60vh] flex-col gap-2 overflow-y-auto overscroll-contain">
       {newEntries.map((entry) => (
         <FeedEntryCard
           key={entry.id}

--- a/ui/src/pages/home-landing/HomeLanding.tsx
+++ b/ui/src/pages/home-landing/HomeLanding.tsx
@@ -529,13 +529,14 @@ export function HomeLanding() {
         </div>
 
         {/* Middle column: Main content + Quick Access.
-            overflow-y-auto (not -hidden) so a tall section — e.g. an expanded
-            Feed entry — scrolls into view instead of being clipped under the
-            footer; min-h-0 lets it actually shrink to its flex track so the
-            scroll engages. */}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
-          {/* Main content area - shrink-0 so it never collapses */}
-          <div className="flex shrink-0 flex-col items-center gap-6 pb-6 text-center">
+            overflow-hidden so the column itself NEVER scrolls — the only scroll
+            region is the Feed, which is flex-1/min-h-0 and absorbs the leftover
+            column height (see Feed.tsx). The hero (greeting + input) stays
+            pinned on top and Quick Access / notifications sit below the feed;
+            gap-6 keeps the original inter-section spacing. */}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-6 overflow-hidden">
+          {/* Hero — fixed at the top, never scrolls */}
+          <div className="flex shrink-0 flex-col items-center gap-6 text-center">
             <h1 className="text-4xl font-bold tracking-tight">
               Hey{' '}
               <span className="bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">{firstName}</span>
@@ -559,9 +560,13 @@ export function HomeLanding() {
                 </button>
               </div>
             </div>
+          </div>
 
-            <Feed />
+          {/* Feed — the single scroll region; grows to fill the leftover height */}
+          <Feed />
 
+          {/* Quick Access — fixed below the feed */}
+          <div className="flex shrink-0 flex-col items-center gap-6 text-center">
             <div className="w-full max-w-3xl">
               <MiniDesktop />
             </div>
@@ -570,7 +575,6 @@ export function HomeLanding() {
               variant="strip"
               className="w-full max-w-3xl flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-1.5 text-xs hover:bg-muted/60 transition-colors text-left"
             />
-
           </div>
 
           {/* Post-scan results panel — shown after scan completes when user hasn't searched yet */}


### PR DESCRIPTION
## Summary
Fixes for conversation/diagnose feed behavior (FLOWPAD-1887). All 4 commits on this branch:

- **Feed entry for UI diagnose even when fine** — a diagnose run now always creates a feed entry, not only on failure.
- **Wait for image load before executing prompt** + a message that diagnose can run in the background (on defocus).
- **Fix feed scrollbar.**
- **Teach the agent how to build a search query** (flowpad-assistance skill).

## Changes
- `flow_sdk/app/actions/diagnose_action.py`, `execute_prompt.py`, `builtin/feed_entry.py`
- `flow_sdk/cli/commands/diagnose_cmd.py`, `cloud_client/hub_bridge.py`
- UI: `Feed.tsx`, `HomeLanding.tsx`, `version-popover/diagnose-modal.tsx`, `ts_sdk/.../feed-entry.ts`
- New skill doc: `flowpad-assistance/search.md`
- Tests: `tests/cli/test_diagnose_cmd.py`, `tests/unit/test_hub_bridge_prompt_gate.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)