### PR TITLE
fix(db): don't reject updating an existing row with null created_by

### DIFF
--- a/flow_sdk/db/drivers/sqlite/sqlite_driver.py
+++ b/flow_sdk/db/drivers/sqlite/sqlite_driver.py
@@ -1104,8 +1104,16 @@ class SQLiteDBDriver(DBDriver):
 
     async def _update_entity(self, entity: DBBaseRecord, session: AsyncSession) -> DBBaseRecord:
         """Update an existing entity. Outer _session_ctx drives commit."""
-        # Check if this is a create attempt on existing entity (matching NetworkX behavior)
-        if not hasattr(entity, "created_by") or entity.created_by is None:
+        # A row only reaches here after ``save()`` has SELECTed it and confirmed
+        # it exists, so a null ``created_by`` is NOT a create-on-existing
+        # collision. It is a legitimate hub-origin reflection: the hub stamps no
+        # owner (``initiated_by``) for share/diagnostics conversations, so the
+        # receiver faithfully reflects ``created_by=None`` — and a later backfill
+        # (participants/title/parent) must still be able to UPDATE that row.
+        # Rejecting it here aborted invitation-preview + bundle unpack, so the
+        # recipient never saw the messages or their attachments. Reject only a
+        # structurally malformed entity (the field missing entirely).
+        if not hasattr(entity, "created_by"):
             raise HTTPException(status_code=400, detail=f"Entity with ID {entity.id} already exists")
 
         self.apply_update_fields(entity)

--- a/tests/unit/test_sqlite_driver_hardening.py
+++ b/tests/unit/test_sqlite_driver_hardening.py
@@ -117,6 +117,42 @@ class TestCountEntitiesByType:
         assert await driver.count_entities_by_type(None) == 3
 
 
+class TestUpdateNullCreatedBy:
+    @pytest.mark.asyncio
+    async def test_update_existing_row_with_null_created_by_succeeds(self, driver):
+        """Regression (soc2 missing attachments): a hub-origin reflection persists
+        with ``created_by=None`` — the hub stamps no owner (``initiated_by``) for
+        share/diagnostics conversations, and the receiver reflects that verbatim.
+
+        Re-saving that already-existing row to backfill fields (participants /
+        title / parent during invitation-preview + bundle unpack) must UPDATE it.
+        ``_update_entity`` used to treat the null ``created_by`` as a
+        create-on-existing collision and raise ``... already exists``, which
+        aborted the unpack so the recipient never saw the messages or their
+        attachments. The row provably exists by the time we reach the update, so
+        a null owner is legitimate and the update must proceed.
+        """
+        from flow_sdk.core.entity.entity_model import remote_reflection
+        from flow_sdk.builtin.agentic_process import AgenticProcess
+
+        p = AgenticProcess(session_id="soc2")
+        # Reflect a hub-origin row: created_by stays null (no fabricated owner).
+        with remote_reflection():
+            await driver.save(p)
+        existing = await driver.get_all(QueryFilter(type=AgenticProcess.get_type()))
+        assert len(existing) == 1
+        assert existing[0].created_by is None  # the reflection left it null
+
+        # The backfill re-save (invitation-preview / bundle-unpack update path).
+        p.session_id = "soc2-updated"
+        updated = await driver.save(p)  # must NOT raise "... already exists"
+        assert updated.session_id == "soc2-updated"
+
+        reloaded = await driver.get_all(QueryFilter(type=AgenticProcess.get_type()))
+        assert len(reloaded) == 1
+        assert reloaded[0].session_id == "soc2-updated"
+
+
 class TestGetAllJsonFieldFilter:
     def test_unknown_kwarg_raises(self):
         """QueryFilter(unknown_field=X) must raise, not silently drop the filter."""


### PR DESCRIPTION
## Problem
Recipients stopped seeing incoming messages and their attachments (soc2 incident). The `.flowmsg` bundle unpack and invitation-preview crashed with `400: Entity with ID <uuid> already exists`.

## Root cause
A hub-origin reflection legitimately persists with `created_by=None` — the hub stamps no owner (`initiated_by`) for share/diagnostics conversations, and the receiver mirrors that verbatim (intended behavior, introduced by `b15e0c72`). But `sqlite_driver._update_entity` had a March-era guard that treats a null `created_by` as a "create-on-existing" collision and raises `... already exists`.

`_update_entity` is only ever reached after `save()` has SELECTed the row and confirmed it **exists**, so a null `created_by` is not a collision — it's a valid update (backfilling participants/title/parent). The guard aborted the unpack, so messages/attachments never materialized.

## Fix
Reject only a structurally malformed entity (the `created_by` attribute missing entirely). A present row with a null `created_by` is a legitimate update and proceeds.

## Test
`tests/unit/test_sqlite_driver_hardening.py::TestUpdateNullCreatedBy` — re-saving a reflected (`created_by=None`) row must update, not raise. Verified it fails with the exact `... already exists` error before the fix and passes after.

> Companion hub-side change (records the real creator in `initiated_by` so reflections carry a non-null author) is flowpad-hub PR #1039 / `v0.29.46`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)