### PR TITLE
fix(bundle): don't pack .venv/cache into shared assets; long-path-safe unpack

### DIFF
--- a/flow_sdk/builtin/flow_message_bundle.py
+++ b/flow_sdk/builtin/flow_message_bundle.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 import tempfile
 import zipfile
@@ -522,6 +523,18 @@ def _restore_spec_source(spec_file: Path, entry_id: str, staging_root: Path) -> 
 
 
 
+# Build/environment artifacts that must never ride inside a shared asset
+# bundle. They are regenerable cruft, not skill source, and their deeply
+# nested trees (a `.venv` ships `…/site-packages/pip/_internal/…/__pycache__/
+# *.pyc`) blow past Windows' 260-char MAX_PATH on the receiver's extractall —
+# which silently aborts the whole download. Keep this in sync with the spirit
+# of a `.gitignore`: ship source, not built environments.
+_ASSET_PACK_IGNORE = shutil.ignore_patterns(
+    ".venv", "venv", "env", "__pycache__", "*.pyc", "*.pyo",
+    "node_modules", ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+)
+
+
 async def _pack_fs_rooted_attachment(
     entry_type: str, entry_id: str, attachment_dir: Path,
 ) -> None:
@@ -530,6 +543,10 @@ async def _pack_fs_rooted_attachment(
     Bundle layout: ``attachment/<type>-@<id>/.claude/<relative-path>``. Format
     is unchanged from the source — the indexer reads exactly the same shape
     on disk in production, so unpack just needs to restore + reindex.
+
+    Build/environment cruft (``.venv``, ``__pycache__``, ``node_modules``, …)
+    is filtered out via ``_ASSET_PACK_IGNORE`` — it isn't asset source and its
+    deep paths break extraction on Windows.
     """
     src = await _fs_rooted_asset_path(entry_type, entry_id)
     if src is None or not src.exists():
@@ -539,7 +556,7 @@ async def _pack_fs_rooted_attachment(
     dest = dest_root / rel
     dest.parent.mkdir(parents=True, exist_ok=True)
     if src.is_dir():
-        shutil.copytree(src, dest, dirs_exist_ok=True)
+        shutil.copytree(src, dest, dirs_exist_ok=True, ignore=_ASSET_PACK_IGNORE)
         # Folder assets (whiteboard, skill) key their id off the main doc's
         # frontmatter id, falling back to a name/path-derived value that won't
         # match the sender's entity id. Pin the sender's id into the main doc so
@@ -859,6 +876,21 @@ async def _create_prompt_from_file(prompt_file: Path, prompt_id: str, owner_type
         logger.warning("unpack_bundle: could not create Prompt from %s: %s", prompt_file, e)
 
 
+def _extended_length_path(p: Path) -> Path:
+    """Return ``p`` as a Windows extended-length (``\\\\?\\``) path so writes
+    under it bypass the 260-char MAX_PATH limit. No-op off Windows and when the
+    prefix is already present. The prefix requires a fully-qualified,
+    backslash-separated path with no ``.``/``..`` components, so resolve first."""
+    if os.name != "nt":
+        return p
+    resolved = os.path.abspath(str(p))
+    if resolved.startswith("\\\\?\\"):
+        return Path(resolved)
+    if resolved.startswith("\\\\"):  # UNC: \\server\share -> \\?\UNC\server\share
+        return Path("\\\\?\\UNC" + resolved[1:])
+    return Path("\\\\?\\" + resolved)
+
+
 async def unpack_bundle(
     zip_path: Path,
     local_user_id: str,
@@ -888,9 +920,14 @@ async def unpack_bundle(
 
     tmp_root = Path(tempfile.mkdtemp(prefix="flowmsg_unpack_"))
     try:
-        # 1. Extract zip
+        # 1. Extract zip. On Windows, anchor extraction at an extended-length
+        # (``\\?\``) path so members whose full path exceeds the 260-char
+        # MAX_PATH still extract instead of raising FileNotFoundError mid-way
+        # (which would silently abort the whole unpack). Hardening in depth —
+        # the packer already strips the deep `.venv`/cache trees that used to
+        # trip this; this keeps a legitimately-deep asset from breaking a share.
         with zipfile.ZipFile(zip_path, "r") as zf:
-            zf.extractall(tmp_root)
+            zf.extractall(_extended_length_path(tmp_root))
 
         # 2. Read top-level header.json
         msg_data = _read_entity_header(tmp_root)

--- a/tests/unit/test_fs_rooted_bundle_id.py
+++ b/tests/unit/test_fs_rooted_bundle_id.py
@@ -8,11 +8,18 @@ The packer injects the sender's id into the asset's main markdown doc so the
 receiver's gen_id (which preserves an existing frontmatter id) materializes the
 SAME entity. This locks both that contract and the type registration.
 """
+import os
+import shutil
+import zipfile
+from pathlib import Path
+
 import pytest
 
 from flow_sdk.builtin.flow_message_bundle import (
+    _ASSET_PACK_IGNORE,
     _FS_ROOTED_TYPES,
     _ensure_id_in_md_frontmatter,
+    _extended_length_path,
 )
 from flow_sdk.schema.types import EntityType
 
@@ -71,3 +78,96 @@ def test_overwrites_a_foreign_id(tmp_path):
 
     from flow_sdk.fs_store.indexer._frontmatter import _extract_frontmatter, _yaml_load
     assert _yaml_load(_extract_frontmatter(doc.read_text(encoding="utf-8")))["id"] == ENTITY_ID
+
+
+# --- Pack-side fix: never bundle a `.venv`/cache into a shared asset ---------
+#
+# A skill packed with its `.venv` shipped a deep
+# `…/site-packages/pip/_internal/…/__pycache__/*.pyc` tree that overran
+# Windows' 260-char MAX_PATH on the receiver's extractall, silently aborting
+# the whole download. The packer copies with ``ignore=_ASSET_PACK_IGNORE``;
+# this locks that those env/cache trees are dropped while real source rides.
+
+def test_asset_pack_ignore_drops_env_and_cache_trees(tmp_path):
+    src = tmp_path / "skills" / "soc2-evidence-renewal"
+    # Real skill source that MUST survive.
+    (src).mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: soc2\n---\n\n# do the thing\n", encoding="utf-8")
+    (src / "scripts").mkdir()
+    (src / "scripts" / "run.py").write_text("print('hi')\n", encoding="utf-8")
+    # Env/cache cruft that MUST be dropped (mirrors the failing bundle).
+    venv_deep = src / ".venv" / "lib" / "site-packages" / "pip" / "__pycache__"
+    venv_deep.mkdir(parents=True)
+    (venv_deep / "build_tracker.cpython-314.pyc").write_text("x", encoding="utf-8")
+    (src / "scripts" / "__pycache__").mkdir()
+    (src / "scripts" / "__pycache__" / "run.cpython-314.pyc").write_text("x", encoding="utf-8")
+    (src / "node_modules").mkdir()
+    (src / "node_modules" / "left-pad.js").write_text("x", encoding="utf-8")
+
+    dest = tmp_path / "bundle" / "soc2"
+    shutil.copytree(src, dest, ignore=_ASSET_PACK_IGNORE)
+
+    # Source preserved.
+    assert (dest / "SKILL.md").exists()
+    assert (dest / "scripts" / "run.py").exists()
+    # Env/cache dropped entirely.
+    assert not (dest / ".venv").exists()
+    assert not (dest / "node_modules").exists()
+    assert not (dest / "scripts" / "__pycache__").exists()
+    assert not list(dest.rglob("*.pyc"))
+
+
+# --- Unpack-side hardening: Windows long-path extraction --------------------
+#
+# (We don't fake ``os.name`` to exercise the off-Windows branch — that global
+# also drives pathlib and would break Path on the host. The non-nt branch is a
+# trivial ``return p``; we cover the load-bearing Windows behavior directly.)
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows extended-length path semantics")
+def test_extended_length_path_prefixes_and_is_idempotent(tmp_path):
+    out = str(_extended_length_path(tmp_path))
+    assert out.startswith("\\\\?\\")
+    # Re-wrapping an already-prefixed path must not double-prefix.
+    assert _extended_length_path(_extended_length_path(tmp_path)) == _extended_length_path(tmp_path)
+
+
+# The bug, captured at the extraction primitive (real zip, real FS, no mocks).
+# A shared skill carrying a `.venv` produced this exact member path; on the
+# receiver, ``zf.extractall`` into a plain root raised FileNotFoundError once
+# the full path crossed 260 chars (MAX_PATH), aborting the whole download so
+# the skill never materialized and its chip stayed on "download". The proven
+# on/off switch is the extended-length (``\\?\``) prefix on the extraction
+# root — this test toggles it BOTH ways: OFF reproduces the bug, ON is the fix.
+@pytest.mark.skipif(os.name != "nt", reason="MAX_PATH (260) is a Windows-only extraction limit")
+def test_deep_bundle_member_extracts_only_with_extended_length_root(tmp_path):
+    deep_arc = (
+        "attachment/skill-@359c3e7b-eac8-40fe-863b-74379f527fa2/.claude/skills/"
+        "soc2-evidence-renewal/.venv/lib/python3.14/site-packages/pip/_internal/"
+        "operations/build/__pycache__/build_tracker.cpython-314.pyc"
+    )
+    zip_path = tmp_path / "bundle.flowmsg"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr(deep_arc, b"x")
+
+    # Precondition: the extracted path must actually exceed MAX_PATH, else the
+    # bug can't manifest and this test would prove nothing.
+    plain_root = tmp_path / "off"
+    plain_root.mkdir()
+    target = plain_root / deep_arc.replace("/", os.sep)
+    assert len(str(target)) > 260, f"path only {len(str(target))} chars; widen tmp or arcname"
+
+    # SWITCH OFF — plain root: reproduces the production failure exactly.
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        with pytest.raises(FileNotFoundError):
+            zf.extractall(plain_root)
+
+    # SWITCH ON — extended-length root (the fix): extraction succeeds and the
+    # deep member lands. Presence is checked via the extended-length path
+    # because a plain ``.exists()`` on a 260+ char path also fails MAX_PATH.
+    ext_root = tmp_path / "on"
+    ext_root.mkdir()
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(_extended_length_path(ext_root))
+    landed = Path(str(_extended_length_path(ext_root)) + os.sep + deep_arc.replace("/", os.sep))
+    assert landed.exists()
+    assert landed.read_bytes() == b"x"


### PR DESCRIPTION
## Problem

When a skill is shared in a conversation, the recipient sees the chip's **download progress bar complete, but the chip stays on "download"** and never flips to the existing entity.

Traced from the `ALice_Dev` instance logs (conversation `ff798dfb-…`, skill `soc2-evidence-renewal`): the body download returns `200 OK` (so the bar finishes), but `unpack_bundle`'s `zf.extractall` then throws:

```
FileNotFoundError: [Errno 2] No such file or directory:
'…\Temp\flowmsg_unpack_…\attachment\skill-@359c3e7b-…\.claude\skills\
 soc2-evidence-renewal\.venv\lib\python3.14\site-packages\pip\_internal\
 operations\build\__pycache__\build_tracker.cpython-314.pyc'   (262 chars)
```

The skill was packed **with its entire `.venv`**, whose deeply nested `pip`/`__pycache__` tree crosses Windows' 260-char `MAX_PATH`. `extractall` aborts mid-way → `unpack_bundle` raises → `_download_and_unpack_bundle` returns `False` → the skill entity is never materialized locally → the chip never updates.

## Fix

- **Pack side (root cause):** `_pack_fs_rooted_attachment` now copies the asset subtree with `ignore=_ASSET_PACK_IGNORE`, dropping `.venv`/`venv`/`env`/`__pycache__`/`*.pyc`/`*.pyo`/`node_modules`/`.git`/cache dirs. These are regenerable environment cruft, never asset source — and what created the pathological paths.
- **Unpack side (hardening):** `unpack_bundle` anchors `extractall` at a Windows extended-length (`\?\`) path via a new `_extended_length_path()` helper (no-op off Windows; handles UNC; idempotent), so a legitimately deep member can't blow past `MAX_PATH` and silently break a share.

## Tests — `tests/unit/test_fs_rooted_bundle_id.py`

Reproduce the failure through the **real mechanism** (real zip, real filesystem, no mocks):

- `test_asset_pack_ignore_drops_env_and_cache_trees` — builds a skill with `.venv`/`__pycache__`/`node_modules`, asserts source survives and all env/cache is dropped.
- `test_deep_bundle_member_extracts_only_with_extended_length_root` — toggles the proven on/off switch **both ways**: a plain extraction root raises the exact production `FileNotFoundError`; the extended-length root extracts the 262-char member successfully.
- `test_extended_length_path_prefixes_and_is_idempotent` — `\?\` prefix added, no double-prefix.

8/8 pass in the file; related bundle/roundtrip suites (20 tests) stay green. No test timeouts raised or added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)