### PR TITLE
fix(schema): UsageReport TypeMetadata uses renamed gen_uuid_fn kwarg

### DIFF
--- a/flow_sdk/schema/type_info/usage_report_type_info.py
+++ b/flow_sdk/schema/type_info/usage_report_type_info.py
@@ -54,7 +54,7 @@ def _usage_report_default_body(entity) -> Optional[str]:
 USAGE_REPORT = TypeMetadata(
     type=EntityType.USAGE_REPORT,
     from_disk_fn=extract_usage_report,
-    gen_id_fn=usage_report_gen_id,
+    gen_uuid_fn=usage_report_gen_id,
     indexed_by_default=True,
     browseable_by=ViewMode.ADVANCED,
     creatable=False,


### PR DESCRIPTION
## Summary
The server failed to boot on `release/v0.2` with:

```
TypeError: TypeMetadata.__init__() got an unexpected keyword argument 'gen_id_fn'
  at flow_sdk/schema/type_info/usage_report_type_info.py:54 (USAGE_REPORT = TypeMetadata(...))
```

## Cause
The UsageReport feature landed on `release/v0.2` using `gen_id_fn=`, but FLOWPAD-1891 renamed that `TypeMetadata` parameter to `gen_uuid_fn`. The merged tree therefore passes a kwarg `TypeMetadata.__init__` no longer accepts, crashing at import time (`register_all` → `usage_report_type_info`).

## Fix
One line: `gen_id_fn=` → `gen_uuid_fn=`. The id function itself (`usage_report_gen_id`) is already entity-id-policy compliant — it mints a v5 UUID via `mint_uuid` and validates adopted ids via `adopt_entity_id` — so no other change was needed.

## Testing
- `import flow_sdk.fs_store.indexer.registrations` (runs `register_all()`) now loads clean.
- Repo-wide grep confirms no remaining `gen_id_fn=` kwargs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)