### PR TITLE
ci: run fast tests on PRs + gate PyPI publish on test status

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,62 @@
+name: PR Tests
+
+# Runs the fast, backend-free test tiers on every pull request.
+#
+# NON-BLOCKING BY DESIGN: these jobs must NOT be added to the branch-protection
+# "required status checks" list — a PR can merge while they are red or pending.
+# They still report true pass/fail, because the PyPI deploy gate
+# (docs/pypi-deploy.md → "Test gate") reads this status to decide whether to
+# publish. Making them required here, or forcing them green, would break that gate.
+#
+# "deep_testing" tiers are intentionally EXCLUDED (they need a live backend or are
+# heavy): pytest tests/long_tests, tests/migration_e2e, tests/pty_fuzz,
+# tests/hub_tests; vitest long, headless, hub, hub-paired. Only the
+# backend-free tiers run here.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: pr-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: backend (pytest unit + cli)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv + Python 3.10
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.10"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run pytest (unit + cli)
+        run: uv run pytest tests/unit tests/cli -v
+
+  frontend:
+    name: frontend (vitest unit + react)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ui
+        run: npm ci
+
+      - name: Run vitest (unit + react)
+        working-directory: ui
+        run: npm run test:vitest:unit && npm run test:vitest:react

--- a/docs/pypi-deploy.md
+++ b/docs/pypi-deploy.md
@@ -8,6 +8,8 @@ id: 684208ee-360e-50e6-a71e-b642ca95ac57
 
 - PyPI credentials configured (either `TWINE_API_TOKEN` env var or `~/.pypirc`)
 - `uv` installed (or `python3 -m build` / `python3 -m twine` as fallback)
+- `gh` authenticated (used by the [Test gate](#test-gate-publishing-requires-the-release-prs-tests-to-have-passed) to read PR check status)
+- `SLACK_BOT_TOKEN` set — a Slack bot token (scopes `chat:write` + `users:read.email`), used only by the Test gate to DM the person running the deploy about blocked / publish-anyway releases. The recipient is resolved from `git config user.email`, so that must be your Slack email. Keep the token secret; never echo it.
 
 ## Quick Deploy (the full end-to-end flow: commit → PR → merge → deploy → branch next)
 
@@ -49,6 +51,21 @@ gh pr create --base "$RELEASE_BRANCH" --head "$DEV_BRANCH" \
 gh pr merge "$DEV_BRANCH" --merge --delete-branch=false
 git fetch origin "$RELEASE_BRANCH"
 
+# --- 2b. TEST GATE: the latest PR merged into the release branch must have GREEN
+#     PR Tests before we publish. Pending counts as "not passed". See the
+#     "Test gate" section below for the block / Slack / publish-anyway rules.
+GATE_JSON=$(gh pr list --base "$RELEASE_BRANCH" --state merged --limit 1 \
+  --json number,url --jq '.[0]')
+PR_NUM=$(echo "$GATE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['number'])")
+PR_URL=$(echo "$GATE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])")
+if gh pr checks "$PR_NUM"; then
+  TESTS_PASSED=1                                  # all checks green → ok to publish
+else
+  TESTS_PASSED=0                                  # any failing OR pending → blocked
+fi
+# If TESTS_PASSED=0: do NOT run step 3. Post the "NOT deployed" Slack message
+# (below) and STOP — unless the user has explicitly said publish anyway.
+
 # --- 3. DEPLOY: bump + build + publish from an isolated worktree on the release branch.
 #     Pick the new patch off the HIGHER of PyPI and the branch (never go backwards).
 PYPI=$(curl -s https://pypi.org/pypi/flowpad/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
@@ -83,6 +100,58 @@ a throwaway worktree — so the main working tree stays on the dev branch the wh
 time. Only step 4 (`git branch -m`) touches it, renaming the branch in place to
 `$NEW-fixes` (the version just deployed; same commit, new name) and merging in
 the release bump.
+
+## Test gate (publishing requires the release PR's tests to have passed)
+
+**A version is only published to PyPI if the latest PR merged into the release
+branch has GREEN PR Tests.** The `PR Tests` workflow (`.github/workflows/pr-tests.yml`)
+runs the fast backend-free tiers (pytest `unit`+`cli`, vitest `unit`+`react`) on
+every PR. It is intentionally **non-blocking for merge** — a PR can be merged
+while its tests are red or still running — so this gate is the point where the
+test result actually matters. **Pending counts as "not passed"**: if the checks
+haven't finished, treat it as not passed and do not publish.
+
+The Slack notice is a **direct message to whoever ran this deploy** — not a
+shared channel. The recipient is resolved from `git config user.email` (so that
+must match your Slack email). Define this helper once before the cases below:
+
+```bash
+# DM the deploying user via Slack. $SLACK_BOT_TOKEN needs chat:write +
+# users:read.email. Never echo the token.
+slack_dm() {
+  local text="$1" uid
+  uid=$(curl -fsS "https://slack.com/api/users.lookupByEmail?email=$(git config user.email)" \
+    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit('Slack lookup failed: '+str(d.get('error'))) if not d.get('ok') else print(d['user']['id'])") || return 1
+  curl -fsS -X POST https://slack.com/api/chat.postMessage \
+    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    -H 'Content-type: application/json; charset=utf-8' \
+    --data "$(python3 -c "import json,sys; print(json.dumps({'channel': sys.argv[1], 'text': sys.argv[2]}))" "$uid" "$text")" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit('Slack post failed: '+str(d.get('error'))) if not d.get('ok') else None"
+}
+```
+
+Step 2b above computes `TESTS_PASSED`, `PR_NUM`, and `PR_URL`. Then:
+
+* **`TESTS_PASSED=1`** → proceed with step 3 and publish normally. No Slack message.
+
+* **`TESTS_PASSED=0` and the user has NOT said to publish anyway** → **do not run
+  step 3.** DM the deploying user that it was blocked and STOP, telling them the
+  tests didn't pass and linking the PR:
+
+  ```bash
+  slack_dm "⚠️ flowpad $NEW was NOT deployed to PyPI — tests did not pass in PR #$PR_NUM: $PR_URL"
+  ```
+
+* **`TESTS_PASSED=0` but the user explicitly says "publish anyway" / insists in
+  any way** → run step 3 (publish) regardless, then DM the deploying user that it
+  shipped with failing/pending tests:
+
+  ```bash
+  slack_dm "🚀 flowpad $NEW was deployed to PyPI even though tests did NOT pass in PR #$PR_NUM: $PR_URL"
+  ```
+
+Only these two cases send Slack. A clean, gated release (`TESTS_PASSED=1`) is silent.
 
 ## Validate Before Publishing
 


### PR DESCRIPTION
## What

- **New CI workflow** `.github/workflows/pr-tests.yml` — runs on every PR:
  - `backend`: `uv run pytest tests/unit tests/cli`
  - `frontend`: `npm run test:vitest:unit && npm run test:vitest:react`
  - Excludes the deep/backend-requiring tiers (pytest `long_tests`, `migration_e2e`, `pty_fuzz`, `hub_tests`; vitest `long`, `headless`, `hub`, `hub-paired`).
  - **Non-blocking for merge by design** — do NOT add these to branch-protection required checks. They still report real pass/fail so the deploy gate can read them.

- **`docs/pypi-deploy.md` Test gate** — a version is published only if the latest PR merged into the release branch has green PR Tests (pending counts as not passed). Otherwise the deploy is blocked and the deploying user gets a Slack DM; if they insist, it publishes anyway and DMs that it shipped without passing tests.

## Setup required
- One Slack app/bot token for the team with `chat:write` + `users:read.email`, exported locally as `SLACK_BOT_TOKEN`; each dev's git email must match their Slack email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)