### PR TITLE
TEST: deliberately failing test to exercise the PyPI deploy gate

### DIFF
--- a/tests/unit/test_ci_gate_smoke.py
+++ b/tests/unit/test_ci_gate_smoke.py
@@ -1,0 +1,9 @@
+"""TEMPORARY: a deliberately failing test to exercise the PyPI deploy Test gate.
+
+This forces the `PR Tests` workflow red so we can verify the deploy skill blocks
+publishing and sends the Slack DM. DELETE this file once the gate is verified.
+"""
+
+
+def test_ci_gate_is_red_on_purpose():
+    assert False, "intentional failure to test the PyPI deploy gate; delete this file"


### PR DESCRIPTION
Temporary PR to verify the PyPI deploy **Test gate**.

Adds `tests/unit/test_ci_gate_smoke.py`, a single always-failing test, so the
`PR Tests` workflow goes **red**. We merge this (non-blocking) and then run the
deploy skill to confirm it **blocks publish** and **Slack-DMs** the deployer.

Delete `tests/unit/test_ci_gate_smoke.py` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)