### PR TITLE
chore: remove temporary CI-gate smoke test

### DIFF
--- a/tests/unit/test_ci_gate_smoke.py
+++ b/tests/unit/test_ci_gate_smoke.py
@@ -1,9 +1,0 @@
-"""TEMPORARY: a deliberately failing test to exercise the PyPI deploy Test gate.
-
-This forces the `PR Tests` workflow red so we can verify the deploy skill blocks
-publishing and sends the Slack DM. DELETE this file once the gate is verified.
-"""
-
-
-def test_ci_gate_is_red_on_purpose():
-    assert False, "intentional failure to test the PyPI deploy gate; delete this file"


### PR DESCRIPTION
Removes `tests/unit/test_ci_gate_smoke.py` — the always-failing test added in
#142 to exercise the PyPI deploy **Test gate**.

The gate is now verified end-to-end:
- ⚠️ blocked path → "NOT deployed, tests didn't pass" DM
- 🚀 publish-anyway path → real PyPI publish (0.2.76) + "deployed even though tests didn't pass" DM

With the test gone, `release/v0.2` CI goes green again and future deploys are no longer blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)