### PR TITLE
FLOWPAD-1896: Diagnosis entity viewer + email report

### DIFF
--- a/flow_sdk/app/actions/__init__.py
+++ b/flow_sdk/app/actions/__init__.py
@@ -13,3 +13,4 @@ from . import prompt_pin_action
 from . import wiki_action
 from . import members_action
 from . import diagnose_action
+from . import report_action

--- a/flow_sdk/app/actions/diagnose_action.py
+++ b/flow_sdk/app/actions/diagnose_action.py
@@ -151,6 +151,6 @@ async def diagnose_post_feed() -> ApiResponse:
         summary = (getattr(diag, "summary", None) or getattr(diag, "title", None) or "") if diag else ""
 
     feed_entry_id = await _post_home_feed_entry(
-        summary=summary, conversation_id=conv_id, flow_message_id=msg_id
+        summary=summary, conversation_id=conv_id, flow_message_id=msg_id, diagnosis_id=diag_id
     )
     return ApiSuccessResponse(data={"feed_entry_id": feed_entry_id})

--- a/flow_sdk/app/actions/report_action.py
+++ b/flow_sdk/app/actions/report_action.py
@@ -1,0 +1,141 @@
+"""`report` graph action — email a diagnosis to the Flowpad team.
+
+The Home-Feed / diagnose-modal "Report issue" button calls this null-entity graph
+action the normal way — ``dataManager.callAction(new ActionInfo('report', null,
+null, 'POST'))`` → ``/api/v1/graph/report`` — with ``{diagnosis_id}`` in the body.
+
+It loads the ``flowpad_diagnosis`` record, pulls out the interesting parts (what
+happened, the user's own words, who/when/which OS), and hands a ready-to-send
+payload to the **hub**, which holds the SendGrid key and sends the mail to
+``diagnosis@langware.ai``.
+
+Why relay through the hub instead of calling SendGrid here: this backend runs
+**on the user's machine** (pip-installed desktop app), so any API key shipped with
+it would be readable by every user. The key stays server-side on the hub; this
+action just POSTs the report to an **unauthenticated** hub endpoint (mirroring the
+public ``GET /health/version`` probe), so it works whether or not the user is
+cloud-logged-in.
+"""
+from __future__ import annotations
+
+import logging
+import platform as _platform
+from datetime import datetime, timezone
+
+import httpx
+
+from flow_sdk.actions.action_registry import action
+from flow_sdk.request_context.methods import get_current_request_info
+from flow_sdk.responses.response import ApiResponse, ApiSuccessResponse, ApiFailResponse
+
+logger = logging.getLogger(__name__)
+
+# Fixed inbox the diagnosis reports go to. The hub may override/enforce this; we
+# send it explicitly so the intent is visible in the payload.
+REPORT_TO_EMAIL = "diagnosis@langware.ai"
+
+
+def _compose_text(fields: dict[str, str]) -> str:
+    """Assemble a readable plaintext body from the interesting parts, skipping
+    anything empty so the hub can relay it as-is (no formatting logic hub-side)."""
+    sections = [
+        ("What the user reported", fields.get("user_report")),
+        ("Summary", fields.get("summary")),
+        ("Symptoms (observed)", fields.get("symptoms")),
+        ("Root cause", fields.get("rca")),
+        ("Fix", fields.get("fix")),
+    ]
+    meta = [
+        ("User", fields.get("user")),
+        ("When", fields.get("occurred_at")),
+        ("OS", fields.get("os")),
+        ("App version", fields.get("app_version")),
+        ("Diagnosis id", fields.get("diagnosis_id")),
+    ]
+    out: list[str] = []
+    for label, val in sections:
+        if val:
+            out.append(f"## {label}\n{val.strip()}")
+    meta_lines = [f"{label}: {val}" for label, val in meta if val]
+    if meta_lines:
+        out.append("## Details\n" + "\n".join(meta_lines))
+    return "\n\n".join(out)
+
+
+@action.post(action_name="report", types=None)
+async def report() -> ApiResponse:
+    request_info = get_current_request_info()
+    body = (await request_info.get_post_data() if request_info else None) or {}
+    diag_id = (body.get("diagnosis_id") or "").strip() if isinstance(body, dict) else ""
+    if not diag_id:
+        return ApiFailResponse(message="diagnosis_id is required", status_code=400)
+
+    # Load the diagnosis record (same path the diagnose feed action uses).
+    from flow_sdk.fs_store.schema_registry import SchemaRegistry
+    from flow_sdk.schema.types import EntityType
+
+    diag_cls = SchemaRegistry.get_entity_cls(EntityType.FLOWPAD_DIAGNOSIS)
+    diag = await diag_cls.get_by_id(diag_id) if diag_cls else None
+    if diag is None:
+        return ApiFailResponse(message=f"diagnosis {diag_id} not found", status_code=404)
+
+    # Who: best-effort identity (works signed-out — git config / OS / desktop default).
+    from flow_sdk.server.routes.bootstrap import get_email, get_name
+
+    name, email = get_name(), get_email()
+    user_label = f"{name} <{email}>" if name and email else (email or name or "unknown")
+
+    try:
+        from flow_sdk._version import __version__ as app_version
+    except Exception:  # noqa: BLE001
+        app_version = None
+
+    fields = {
+        "diagnosis_id": diag_id,
+        "title": getattr(diag, "title", None) or "",
+        "summary": getattr(diag, "summary", None) or "",
+        "symptoms": getattr(diag, "symptoms", None) or "",
+        "rca": getattr(diag, "rca", None) or "",
+        "fix": getattr(diag, "fix", None) or "",
+        "user_report": getattr(diag, "user_report", None) or "",
+        "user": user_label,
+        # created_date may be a datetime — coerce to str so the JSON body serializes.
+        "occurred_at": str(getattr(diag, "created_date", None) or ""),
+        "os": _platform.platform(),
+        "app_version": app_version or "",
+    }
+
+    title = fields["title"] or "Issue report"
+    payload = {
+        "to": REPORT_TO_EMAIL,
+        "subject": f"[Flowpad diagnosis] {title}",
+        "reported_at": datetime.now(timezone.utc).isoformat(),
+        "text": _compose_text(fields),
+        **fields,
+    }
+
+    # Relay to the hub (holds the SendGrid key). Unauthenticated, non-graph route —
+    # mirrors the public health probe — so it works whether or not the user is
+    # signed in. hub_public_url() returns None in Local (private) mode / when no hub
+    # is configured (no outbound HTTP allowed); surface that as a clean failure.
+    from flow_sdk.cloud_client.transport.hub_http import hub_public_url
+
+    url = hub_public_url("diagnosis-report")
+    if not url:
+        return ApiFailResponse(
+            message="Reporting is unavailable offline (no hub configured).",
+            status_code=503,
+        )
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=payload, timeout=httpx.Timeout(15))
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[report] POST %s transport error: %s", url, e)
+        return ApiFailResponse(message="Could not reach the reporting service.", status_code=502)
+
+    if resp.status_code != 200:
+        logger.warning("[report] POST %s returned %s: %s", url, resp.status_code, resp.text[:300])
+        return ApiFailResponse(message="The reporting service rejected the report.", status_code=502)
+
+    logger.info("[report] emailed diagnosis %s to %s via hub", diag_id, REPORT_TO_EMAIL)
+    return ApiSuccessResponse(data={"sent": True, "diagnosis_id": diag_id})

--- a/flow_sdk/builtin/flowpad_diagnosis.py
+++ b/flow_sdk/builtin/flowpad_diagnosis.py
@@ -29,3 +29,11 @@ class FlowpadDiagnosis(Entity):
     summary: Optional[str] = APIField(
         None, description="One-paragraph plain-language summary of the diagnosis."
     )
+    user_report: Optional[str] = APIField(
+        None,
+        description=(
+            "The user's own free-text description of the issue, typed when they ran "
+            "the diagnosis (empty for a full sweep). Distinct from ``symptoms``, "
+            "which is what the agent observed — this is the raw text the user wrote."
+        ),
+    )

--- a/flow_sdk/builtin/message_suggest.py
+++ b/flow_sdk/builtin/message_suggest.py
@@ -12,6 +12,9 @@ class MessageSuggest(Entity):
     message_text: str = APIField("")
     conversation_id: Optional[str] = APIField(None)
     flow_message_id: Optional[str] = APIField(None)
+    # The recorded flowpad_diagnosis id — lets the card's "Report issue" button
+    # email the diagnosis without re-resolving it from the support message.
+    diagnosis_id: Optional[str] = APIField(None)
     # Discriminates the feed-card variant. "" = diagnosis card (Report/Forward);
     # "draft_reply" = an executed-prompt draft waiting to send (Send/Open).
     kind: str = APIField("")

--- a/flow_sdk/cli/commands/diagnose_cmd.py
+++ b/flow_sdk/cli/commands/diagnose_cmd.py
@@ -147,7 +147,11 @@ class _Renderer:
 
 
 async def _post_home_feed_entry(
-    *, summary: str, conversation_id: str | None = None, flow_message_id: str | None = None
+    *,
+    summary: str,
+    conversation_id: str | None = None,
+    flow_message_id: str | None = None,
+    diagnosis_id: str | None = None,
 ) -> str | None:
     """Post the Home-Feed card for a recorded diagnosis, SDK-direct.
 
@@ -182,6 +186,7 @@ async def _post_home_feed_entry(
             message_text=(summary or "").strip(),
             conversation_id=conversation_id,
             flow_message_id=flow_message_id,
+            diagnosis_id=diagnosis_id,
         )
         suggest = await suggest.save(user.typeid)
         feed = FeedEntry(
@@ -450,6 +455,21 @@ async def _run_diagnose(
             conv_id = recorded.get("conversation_id")
             msg_id = recorded.get("flow_message_id")
             has_issue = bool(conv_id and msg_id)
+
+            # Stamp the user's own free-text description onto the record. report.py
+            # (run by the agent) only ever sees the agent-observed ``symptoms`` — the
+            # raw text the user typed lives only here in the CLI runner — so we persist
+            # it now, after the record exists, where the "Report issue" email reads it.
+            if did and message:
+                with contextlib.suppress(Exception):
+                    from flow_sdk.fs_store.fs_record import FSRecord
+
+                    rec = FSRecord.load_or_none(EntityType.FLOWPAD_DIAGNOSIS.value, did)
+                    if rec is not None:
+                        rec.save_metadata_field("user_report", message)
+                        rec = FSRecord.load_or_none(EntityType.FLOWPAD_DIAGNOSIS.value, did)
+                        if rec is not None:
+                            await rec.sync_to_db()
             if callable(create_feed_entry):
                 want_feed = create_feed_entry(has_issue)
             else:
@@ -480,7 +500,10 @@ async def _run_diagnose(
             if want_feed:
                 summary = (getattr(diag, "summary", None) or getattr(diag, "title", None) or "") if diag else ""
                 feed_entry_id = await _post_home_feed_entry(
-                    summary=summary, conversation_id=conv_id, flow_message_id=msg_id
+                    summary=summary,
+                    conversation_id=conv_id,
+                    flow_message_id=msg_id,
+                    diagnosis_id=did,
                 )
             emit({"type": "status", "text": "  ✓ Diagnostic complete — diagnosis recorded."})
             emit({

--- a/flow_sdk/cloud_client/transport/hub_http.py
+++ b/flow_sdk/cloud_client/transport/hub_http.py
@@ -86,6 +86,18 @@ def hub_base_url() -> Optional[str]:
     return url.rstrip("/") if url else None
 
 
+def hub_public_url(sub_path: str) -> Optional[str]:
+    """Full hub URL for a PUBLIC (non-graph, unauthenticated) API route — e.g.
+    ``health/version`` or ``diagnosis-report`` — or None if the hub isn't
+    configured. The non-graph sibling of ``hub_graph_url``: "public" marks that it
+    targets routes outside ``/graph`` that need no bearer (callable signed-out)."""
+    base = hub_base_url()
+    if not base:
+        return None
+    from flow_sdk.api.api_request import APIRequest
+    return f"{base}{APIRequest.api_prefix}/{sub_path.lstrip('/')}"
+
+
 async def get_info() -> Optional[dict[str, Any]]:
     """Fetch lightweight info about the configured hub.
 
@@ -97,11 +109,9 @@ async def get_info() -> Optional[dict[str, Any]]:
     works even when the user is signed out. Returns ``None`` when the hub is
     not configured (``FLOWPAD_HUB_URL`` unset) or unreachable.
     """
-    base = hub_base_url()
-    if not base:
+    url = hub_public_url("health/version")
+    if not url:
         return None
-    from flow_sdk.api.api_request import APIRequest
-    url = f"{base}{APIRequest.api_prefix}/health/version"
     try:
         async with httpx.AsyncClient() as client:
             resp = await client.get(url, timeout=httpx.Timeout(8))

--- a/flow_sdk/schema/type_info/flowpad_diagnosis_type_info.py
+++ b/flow_sdk/schema/type_info/flowpad_diagnosis_type_info.py
@@ -46,6 +46,14 @@ class FlowpadDiagnosisMetadata(BaseMeta):
         default=None,
         description="One-paragraph plain-language summary of the diagnosis, shown to the user.",
     )
+    user_report: Optional[str] = Field(
+        default=None,
+        description=(
+            "The user's own free-text description of the issue, typed when running "
+            "the diagnosis. Raw user words — distinct from the agent-observed "
+            "``symptoms``. Empty when the user asked for a full sweep."
+        ),
+    )
 
 
 FLOWPAD_DIAGNOSIS = TypeMetadata(

--- a/ts_sdk/src/entities/conversation-send.ts
+++ b/ts_sdk/src/entities/conversation-send.ts
@@ -1,3 +1,5 @@
+import { dataManager } from '../APIEntity';
+import { ActionInfo } from '../models/ActionInfo';
 import { sendReply } from './notifications';
 import {
   Conversation,
@@ -90,6 +92,20 @@ export async function sendDiagnosisReport(
   conv.dismissed_at = null;
   conv.updated_date = new Date().toISOString();
   await conv.save([]);
+}
+
+/**
+ * Email a diagnosis to the Flowpad team. Calls the backend ``report`` action
+ * (``POST /api/v1/graph/report``), which gathers the diagnosis's interesting
+ * parts (what happened, the user's own words, who/when/which OS) and relays them
+ * to the hub — the hub holds the SendGrid key and sends to diagnosis@langware.ai.
+ * Used by the Home-Feed card's and the diagnose modal's "Report issue" button.
+ */
+export async function sendDiagnosisEmailReport(diagnosisId: string): Promise<void> {
+  // Null-entity graph service action → POST /api/v1/graph/report.
+  const info = new ActionInfo('report', null, null, 'POST');
+  info.bodyParameters = { diagnosis_id: diagnosisId };
+  await dataManager.callAction<{ diagnosis_id: string }, { sent: boolean }>(info);
 }
 
 export interface CreateAndSendParams {

--- a/ts_sdk/src/entities/message-suggest.ts
+++ b/ts_sdk/src/entities/message-suggest.ts
@@ -10,6 +10,9 @@ export interface IMessageSuggest extends IEntity {
   conversation_id?: string | null;
   /** The summary FlowMessage in that conversation; issue cards only. */
   flow_message_id?: string | null;
+  /** The recorded FlowpadDiagnosis this card is about; powers the feed View
+   *  button. Present on every diagnosis card (issue and clean-sweep alike). */
+  diagnosis_id?: string | null;
   /** Card variant: "" = diagnosis (Report/Forward), "draft_reply" = a draft
    *  reply waiting to send (Send/Open). */
   kind?: string;
@@ -22,6 +25,7 @@ export class MessageSuggest extends APIEntity<MessageSuggest> implements IMessag
   message_text?: string;
   conversation_id?: string | null;
   flow_message_id?: string | null;
+  diagnosis_id?: string | null;
   kind?: string;
 
   constructor(entity: Partial<IMessageSuggest> = {}) {
@@ -30,6 +34,7 @@ export class MessageSuggest extends APIEntity<MessageSuggest> implements IMessag
     this.message_text = entity.message_text;
     this.conversation_id = entity.conversation_id ?? null;
     this.flow_message_id = entity.flow_message_id ?? null;
+    this.diagnosis_id = entity.diagnosis_id ?? null;
     this.kind = entity.kind;
   }
 

--- a/ts_sdk/src/utils/ui/view-types.ts
+++ b/ts_sdk/src/utils/ui/view-types.ts
@@ -72,6 +72,7 @@ export enum ViewType {
   CONVERSATION = 'conversation', // Single Conversation viewer (avatar bubbles + composer)
   SPEC = 'spec', // Single Spec viewer (shows spec metadata, plan link, generated tasks)
   GRAPH_CONTEXT = 'graph_context', // Frozen-context viewer - /dock/graph_context/<id>
+  DIAGNOSIS = 'diagnosis', // Single FlowpadDiagnosis viewer - /dock/diagnosis/<id>
 }
 
 /**

--- a/ui/src/components/account/system-diagnoses.tsx
+++ b/ui/src/components/account/system-diagnoses.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useMemo, useState, type ComponentType } from 'react';
 import { Button } from '@src/components/ui/button';
 import {
   Dialog,
@@ -15,9 +15,28 @@ import {
   TableHeader,
   TableRow,
 } from '@src/components/ui/table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@src/components/ui/dropdown-menu';
 import { ConfirmDialog } from '@src/components/ui/confirm-dialog';
-import { Stethoscope, Trash2 } from 'lucide-react';
-import { systemTools, FlowpadDiagnosis } from '@sdk';
+import { DiagnosisReportModal } from '@src/components/version-popover/diagnosis-report-modal';
+import { diagnosisToText } from '@src/components/diagnose/diagnosis-details';
+import { deriveConversationTitle } from '@src/components/conversation/conversation-title';
+import { useRecentConversations } from '@src/hooks/use-recent-conversations';
+import { useEntitiesQuery } from '@src/hooks/entity-hooks';
+import { notify } from '@src/notifications';
+import { Copy, Eye, Flag, Forward, Stethoscope, Trash2 } from 'lucide-react';
+import {
+  systemTools,
+  copyToClipboard,
+  sendDiagnosisReport,
+  sendDiagnosisEmailReport,
+  FlowpadDiagnosis,
+  QueryRequest,
+} from '@sdk';
 
 /** Format a record's `created_date` (ISO string or Date) as a local date+time (or em-dash). */
 function formatRecorded(value?: string | Date): string {
@@ -27,37 +46,175 @@ function formatRecorded(value?: string | Date): string {
 }
 
 /**
+ * An icon button that drops down the most-recent conversations and forwards the
+ * diagnosis report to the picked one (via `sendDiagnosisReport`). Used by the
+ * Forward action; "Report" emails the team instead and needs no picker.
+ */
+function ConvPickerButton({
+  icon: Icon,
+  label,
+  onPick,
+  disabled,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  onPick: (conversationId: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const conversations = useRecentConversations(open);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 w-7 p-0"
+          aria-label={label}
+          title={label}
+          disabled={disabled}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Icon className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        {conversations.length === 0 ? (
+          <DropdownMenuItem disabled>No conversations yet.</DropdownMenuItem>
+        ) : (
+          conversations.map((conv) => (
+            <DropdownMenuItem key={conv.id} onSelect={() => onPick(conv.id)}>
+              <span className="truncate">{deriveConversationTitle(conv)}</span>
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Per-row action icons: View, Report, Forward, Copy-all, Dismiss (delete). */
+function DiagnosisRowActions({
+  diag,
+  onView,
+  onDelete,
+}: {
+  diag: FlowpadDiagnosis;
+  onView: () => void;
+  onDelete: () => void;
+}) {
+  // "Report issue" — email the diagnosis to the Flowpad team (no conversation).
+  const handleReport = useCallback(async () => {
+    try {
+      await sendDiagnosisEmailReport(diag.id);
+      notify.success({ title: 'Diagnosis reported to the Flowpad team' });
+    } catch (e) {
+      notify.error({
+        title: 'Could not report diagnosis',
+        message: e instanceof Error ? e.message : 'Report failed.',
+      });
+    }
+  }, [diag]);
+
+  // "Forward" — post the formatted report into the chosen conversation.
+  const handleForward = useCallback(
+    async (conversationId: string) => {
+      try {
+        await sendDiagnosisReport(conversationId, {
+          fallbackText: diag.summary || diag.title || '',
+        });
+        notify.success({ title: 'Diagnosis forwarded' });
+      } catch (e) {
+        notify.error({
+          title: 'Could not forward diagnosis',
+          message: e instanceof Error ? e.message : 'Send failed.',
+        });
+      }
+    },
+    [diag],
+  );
+
+  const handleCopy = useCallback(async () => {
+    await copyToClipboard(diagnosisToText(diag));
+    notify.success({ title: 'Diagnosis copied to clipboard' });
+  }, [diag]);
+
+  return (
+    <div className="flex items-center justify-end gap-0.5" onClick={(e) => e.stopPropagation()}>
+      <Button size="sm" variant="ghost" className="h-7 w-7 p-0" aria-label="View diagnosis" title="View" onClick={onView}>
+        <Eye className="h-4 w-4" />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-7 w-7 p-0"
+        aria-label="Report issue"
+        title="Report issue"
+        onClick={() => void handleReport()}
+      >
+        <Flag className="h-4 w-4" />
+      </Button>
+      <ConvPickerButton icon={Forward} label="Forward" onPick={(id) => void handleForward(id)} />
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-7 w-7 p-0"
+        aria-label="Copy all"
+        title="Copy all"
+        onClick={() => void handleCopy()}
+      >
+        <Copy className="h-4 w-4" />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+        aria-label="Delete diagnosis"
+        title="Delete"
+        onClick={onDelete}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+/**
  * Account-settings entry point for the recorded `flowpad_diagnosis` entities.
- * The button opens a dialog with a table of all diagnoses (title / symptoms /
- * root-cause / fix) and a per-row delete. Backed by
- * `systemTools.getDiagnoses()` / `systemTools.deleteDiagnosis()`.
+ * The button opens a dialog with a reactive table of all diagnoses; each row opens
+ * the diagnosis viewer popup on click and carries View / Report / Forward /
+ * Copy-all / Delete actions. The list is a live entity query, so deletes and newly
+ * recorded diagnoses reflect automatically.
  */
 export function SystemDiagnoses() {
   const [open, setOpen] = useState(false);
-  const [rows, setRows] = useState<FlowpadDiagnosis[]>([]);
-  const [loading, setLoading] = useState(false);
   const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [viewId, setViewId] = useState<string | null>(null);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    try {
-      setRows(await systemTools.getDiagnoses());
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (open) void refresh();
-  }, [open, refresh]);
-
-  const handleDelete = useCallback(
-    async (id: string) => {
-      await systemTools.deleteDiagnosis(id);
-      await refresh();
-    },
-    [refresh],
+  // Reactive list of all recorded diagnoses — subscribes to the entity store, so a
+  // delete (or a freshly recorded diagnosis) updates the table without a manual
+  // refetch. Only queried while the dialog is open.
+  const request = useMemo(
+    () => new QueryRequest({ type: FlowpadDiagnosis.type, scope: [] }),
+    [],
   );
+  const { data, isLoading } = useEntitiesQuery<FlowpadDiagnosis>(request, { enabled: open });
+  const rows = useMemo(
+    () =>
+      [...(data ?? [])].sort(
+        (a, b) =>
+          new Date(b.created_date ?? 0).getTime() - new Date(a.created_date ?? 0).getTime(),
+      ),
+    [data],
+  );
+  const loading = isLoading && rows.length === 0;
+
+  // Delete via dataManager (systemTools.deleteDiagnosis) — the store update flows
+  // back through the query above, so the row disappears on its own.
+  const handleDelete = useCallback(async (id: string) => {
+    await systemTools.deleteDiagnosis(id);
+  }, []);
 
   return (
     <>
@@ -67,11 +224,11 @@ export function SystemDiagnoses() {
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-4xl">
+        <DialogContent className="max-w-3xl">
           <DialogHeader>
             <DialogTitle>System Diagnoses</DialogTitle>
             <DialogDescription>
-              Issue diagnoses recorded by the assistant — title, symptoms, root cause, and fix.
+              Issue diagnoses recorded by the assistant. Click a row to view the full diagnosis.
             </DialogDescription>
           </DialogHeader>
 
@@ -81,36 +238,37 @@ export function SystemDiagnoses() {
             <p className="p-4 text-sm text-muted-foreground">No diagnoses recorded.</p>
           ) : (
             <div className="max-h-[60vh] overflow-y-auto rounded-lg border">
-              <Table>
+              <Table className="table-fixed">
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-[160px]">Title</TableHead>
-                    <TableHead className="w-[150px]">Recorded</TableHead>
-                    <TableHead>Symptoms</TableHead>
-                    <TableHead>Root cause</TableHead>
-                    <TableHead>Fix</TableHead>
-                    <TableHead className="w-[60px] text-right">Actions</TableHead>
+                    <TableHead className="w-[28%]">Title</TableHead>
+                    <TableHead className="w-[22%]">Recorded</TableHead>
+                    <TableHead className="w-[28%]">Summary</TableHead>
+                    <TableHead className="w-[22%] text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {rows.map((d) => (
-                    <TableRow key={d.id}>
-                      <TableCell className="align-top font-medium">{d.title || d.name || '—'}</TableCell>
-                      <TableCell className="align-top whitespace-nowrap text-xs text-muted-foreground">
+                    <TableRow
+                      key={d.id}
+                      className="cursor-pointer"
+                      onClick={() => setViewId(d.id)}
+                    >
+                      <TableCell className="truncate font-medium" title={d.title || d.name || ''}>
+                        {d.title || d.name || '—'}
+                      </TableCell>
+                      <TableCell className="truncate whitespace-nowrap text-xs text-muted-foreground">
                         {formatRecorded(d.created_date)}
                       </TableCell>
-                      <TableCell className="align-top whitespace-pre-wrap text-xs">{d.symptoms || '—'}</TableCell>
-                      <TableCell className="align-top whitespace-pre-wrap text-xs">{d.rca || '—'}</TableCell>
-                      <TableCell className="align-top whitespace-pre-wrap text-xs">{d.fix || '—'}</TableCell>
-                      <TableCell className="text-right align-top">
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          aria-label="Delete diagnosis"
-                          onClick={() => setConfirmId(d.id)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
+                      <TableCell className="truncate text-xs" title={d.summary || ''}>
+                        {d.summary || '—'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <DiagnosisRowActions
+                          diag={d}
+                          onView={() => setViewId(d.id)}
+                          onDelete={() => setConfirmId(d.id)}
+                        />
                       </TableCell>
                     </TableRow>
                   ))}
@@ -120,6 +278,12 @@ export function SystemDiagnoses() {
           )}
         </DialogContent>
       </Dialog>
+
+      <DiagnosisReportModal
+        open={viewId !== null}
+        diagnosisId={viewId ?? undefined}
+        onClose={() => setViewId(null)}
+      />
 
       <ConfirmDialog
         open={confirmId !== null}

--- a/ui/src/components/diagnose/diagnosis-action-buttons.tsx
+++ b/ui/src/components/diagnose/diagnosis-action-buttons.tsx
@@ -3,10 +3,11 @@ import { deriveConversationTitle } from '@src/components/conversation/conversati
 import { useRecentConversations } from '@src/hooks/use-recent-conversations';
 import { formatTimeAgo } from '@src/utils/format-time-ago';
 import { EyeOff, Forward } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 interface DiagnosisActionButtonsProps {
-  /** The suggested support conversation — "Report issue" sends here; excluded from the Forward list. */
+  /** The support conversation — excluded from the Forward list (you don't forward
+   *  a report back into the conversation that already holds it). */
   suggestedConversationId?: string;
   busy?: boolean;
   error?: string;
@@ -14,15 +15,22 @@ interface DiagnosisActionButtonsProps {
   showDismiss?: boolean;
   /** Dismiss the diagnosis surface (Feed card: dismiss the entry; modal: close). */
   onDismiss: () => void;
-  /** Send the report to a conversation — used by both "Report issue" and a Forward pick. */
-  onReport: (conversationId: string) => void;
+  /** "Report issue" — email the diagnosis to the Flowpad team. */
+  onReportIssue: () => void;
+  /** Whether reporting is available (a diagnosis id is known). Defaults to true. */
+  canReport?: boolean;
+  /** "Forward" — post the formatted report into the chosen conversation. */
+  onForward: (conversationId: string) => void;
+  /** Extra control rendered right-most on the button row (e.g. the feed's View button). */
+  trailing?: ReactNode;
 }
 
 /**
  * The action row at the bottom of a diagnosis surface: Dismiss / Report issue /
  * Forward (with a recent-conversation picker). Shared between the Home-Feed
  * `FeedEntryCard` and the UI diagnose modals so both render and behave identically;
- * the data/mutation wiring lives in each caller's `onDismiss` / `onReport`.
+ * the data/mutation wiring lives in each caller's `onDismiss` / `onReportIssue` /
+ * `onForward`. "Report issue" emails the team; "Forward" posts into a conversation.
  */
 export function DiagnosisActionButtons({
   suggestedConversationId,
@@ -30,7 +38,10 @@ export function DiagnosisActionButtons({
   error,
   showDismiss = true,
   onDismiss,
-  onReport,
+  onReportIssue,
+  canReport = true,
+  onForward,
+  trailing,
 }: DiagnosisActionButtonsProps) {
   const [forwardOpen, setForwardOpen] = useState(false);
   // Forward target list: most recent conversations, fetched only while open. The
@@ -57,8 +68,8 @@ export function DiagnosisActionButtons({
         <Button
           type="button"
           size="sm"
-          disabled={busy || !suggestedConversationId}
-          onClick={() => suggestedConversationId && onReport(suggestedConversationId)}
+          disabled={busy || !canReport}
+          onClick={onReportIssue}
           className="h-6 px-2 text-xs"
         >
           Report issue
@@ -76,6 +87,7 @@ export function DiagnosisActionButtons({
           <Forward className="h-3.5 w-3.5" />
           Forward
         </Button>
+        {trailing && <div className="ml-auto flex items-center">{trailing}</div>}
       </div>
 
       {forwardOpen && (
@@ -88,7 +100,7 @@ export function DiagnosisActionButtons({
                 <button
                   type="button"
                   disabled={busy}
-                  onClick={() => onReport(conv.id)}
+                  onClick={() => onForward(conv.id)}
                   className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-2 py-1.5 text-left text-xs text-foreground hover:bg-muted/50 disabled:pointer-events-none disabled:opacity-50"
                   data-testid={`feed-forward-conv-${conv.id}`}
                 >

--- a/ui/src/components/diagnose/diagnosis-details.tsx
+++ b/ui/src/components/diagnose/diagnosis-details.tsx
@@ -1,0 +1,197 @@
+import { DiagnosisActionButtons } from '@src/components/diagnose/diagnosis-action-buttons';
+import {
+  copyToClipboard,
+  FlowpadDiagnosis,
+  sendDiagnosisEmailReport,
+  sendDiagnosisReport,
+  TypeId,
+} from '@sdk';
+import { useEntity } from '@sdk/react/hooks';
+import { notify } from '@src/notifications';
+import { Copy, Loader2 } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+interface DiagnosisDetailsProps {
+  /** The FlowpadDiagnosis entity id (UUID, no type prefix). */
+  diagnosisId: string;
+  /** The suggested support conversation — enables the report buttons (issue only). */
+  conversationId?: string;
+  /** The recorded support FlowMessage — its text is the full formatted report on Forward. */
+  flowMessageId?: string;
+  /** Called after a successful report/forward send (e.g. the modal closes). */
+  onActionDone?: () => void;
+  /**
+   * Typography scale. `'modal'` (default) is the compact popup body; `'page'` is
+   * the full-tab reading layout — larger font, looser line spacing, more air
+   * between sections, to match the other full-screen entity viewers.
+   */
+  variant?: 'modal' | 'page';
+}
+
+interface Field {
+  label: string;
+  value?: string;
+}
+
+/** The four labelled diagnosis fields, in display order. */
+function diagnosisFields(diag: FlowpadDiagnosis): Field[] {
+  return [
+    { label: 'Summary', value: diag.summary },
+    { label: 'Symptoms', value: diag.symptoms },
+    { label: 'Root cause', value: diag.rca },
+    { label: 'Fix', value: diag.fix },
+  ];
+}
+
+/**
+ * Assemble the full diagnosis (title + all fields) as one plain-text blob for the
+ * clipboard. Shared by the details body's Copy button and the settings table's
+ * per-row Copy-all action.
+ */
+export function diagnosisToText(diag: FlowpadDiagnosis): string {
+  const title = diag.title || diag.name || 'Diagnosis';
+  const body = diagnosisFields(diag)
+    .filter((f) => f.value)
+    .map((f) => `${f.label}:\n${f.value}`)
+    .join('\n\n');
+  return body ? `${title}\n\n${body}` : title;
+}
+
+/**
+ * The shared diagnosis body — title, the four fields (summary / symptoms / root
+ * cause / fix), a Copy-all button, and (for a real issue) the same Report/Forward
+ * buttons as a Feed entry. Rendered identically by the popup
+ * (`DiagnosisReportModal`), the routed full-tab viewer (`DiagnosisViewer`), and
+ * the feed's View action, so the three never diverge. Report routes through the
+ * shared `sendDiagnosisReport` — the single report path.
+ */
+export function DiagnosisDetails({
+  diagnosisId,
+  conversationId,
+  flowMessageId,
+  onActionDone,
+  variant = 'modal',
+}: DiagnosisDetailsProps) {
+  const isPage = variant === 'page';
+  const typeId = useMemo(
+    () => (diagnosisId ? new TypeId(FlowpadDiagnosis.type, diagnosisId) : null),
+    [diagnosisId],
+  );
+  const { data: diag, isLoading } = useEntity<FlowpadDiagnosis>(typeId, { enabled: !!typeId });
+
+  const [reporting, setReporting] = useState(false);
+  const [reportError, setReportError] = useState<string | undefined>(undefined);
+
+  const fields: Field[] = diag ? diagnosisFields(diag) : [];
+
+  const handleCopy = useCallback(async () => {
+    if (!diag) return;
+    await copyToClipboard(diagnosisToText(diag));
+    notify.success({ title: 'Diagnosis copied to clipboard' });
+  }, [diag]);
+
+  // "Report issue" — email the diagnosis to the Flowpad team.
+  const handleReportIssue = useCallback(async () => {
+    if (!diagnosisId) return;
+    setReporting(true);
+    setReportError(undefined);
+    try {
+      await sendDiagnosisEmailReport(diagnosisId);
+      onActionDone?.();
+    } catch (e) {
+      setReportError(e instanceof Error ? e.message : 'Failed to send report');
+    } finally {
+      setReporting(false);
+    }
+  }, [diagnosisId, onActionDone]);
+
+  // "Forward" — post the formatted report into the chosen conversation.
+  const handleForward = useCallback(
+    async (targetConversationId: string) => {
+      setReporting(true);
+      setReportError(undefined);
+      try {
+        await sendDiagnosisReport(targetConversationId, {
+          flowMessageId,
+          fallbackText: diag?.summary || diag?.title || '',
+        });
+        onActionDone?.();
+      } catch (e) {
+        setReportError(e instanceof Error ? e.message : 'Failed to send report');
+      } finally {
+        setReporting(false);
+      }
+    },
+    [diag, flowMessageId, onActionDone],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        <span>Loading diagnosis…</span>
+      </div>
+    );
+  }
+
+  if (!diag) {
+    return <p className="text-xs text-muted-foreground">Diagnosis not found.</p>;
+  }
+
+  return (
+    <div className={isPage ? 'space-y-8' : 'space-y-3'}>
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          onClick={() => void handleCopy()}
+          className="flex items-center gap-1.5 rounded-md border border-input bg-background px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          title="Copy diagnosis to clipboard"
+          aria-label="Copy diagnosis to clipboard"
+        >
+          <Copy className="h-3.5 w-3.5" />
+          Copy
+        </button>
+      </div>
+
+      <div className={isPage ? 'space-y-7' : 'space-y-3'}>
+        {fields
+          .filter((f) => f.value)
+          .map((f) => (
+            <div key={f.label} className={isPage ? 'space-y-2' : undefined}>
+              <p
+                className={
+                  isPage
+                    ? 'text-sm font-semibold uppercase tracking-wide text-muted-foreground'
+                    : 'text-[11px] font-semibold uppercase tracking-wide text-muted-foreground'
+                }
+              >
+                {f.label}
+              </p>
+              <p
+                className={
+                  isPage
+                    ? 'whitespace-pre-wrap break-words text-base leading-8 text-foreground'
+                    : 'whitespace-pre-wrap break-words text-xs text-foreground'
+                }
+              >
+                {f.value}
+              </p>
+            </div>
+          ))}
+      </div>
+
+      {/* Same actions as a Feed entry: Report issue emails the team (needs only the
+          diagnosis), Forward posts the report into a chosen conversation. */}
+      <DiagnosisActionButtons
+        suggestedConversationId={conversationId}
+        busy={reporting}
+        error={reportError}
+        showDismiss={false}
+        canReport={!!diagnosisId}
+        onDismiss={() => onActionDone?.()}
+        onReportIssue={() => void handleReportIssue()}
+        onForward={(targetConversationId) => void handleForward(targetConversationId)}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/diagnosis-viewer/DiagnosisViewer.tsx
+++ b/ui/src/components/diagnosis-viewer/DiagnosisViewer.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { FlowpadDiagnosis, TypeId } from '@sdk';
+import { useEntity } from '@sdk/react/hooks';
+import { DiagnosisDetails } from '@src/components/diagnose/diagnosis-details';
+import { iconForType } from '@src/components/graph-view/icons/iconRegistry';
+
+interface DiagnosisViewerProps {
+  /** The FlowpadDiagnosis entity id (dock pointer = /dock/diagnosis/<id>). */
+  pointer?: string;
+}
+
+/**
+ * Routed full-tab viewer for a single FlowpadDiagnosis (`/dock/diagnosis/<id>`).
+ * The URL-first counterpart of the popup: it renders the same `DiagnosisDetails`
+ * body inside page chrome (type icon + title). Reached by clicking the expand
+ * arrow in the popup, or by navigating to the URL directly.
+ */
+export function DiagnosisViewer({ pointer }: DiagnosisViewerProps) {
+  const typeId = useMemo(
+    () => (pointer ? new TypeId(FlowpadDiagnosis.type, pointer) : null),
+    [pointer],
+  );
+  const { data: diag } = useEntity<FlowpadDiagnosis>(typeId, { enabled: !!typeId });
+  const Icon = iconForType(FlowpadDiagnosis.type);
+
+  if (!pointer) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        No diagnosis selected.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-8 py-10">
+        <div className="mb-8 flex items-center gap-3 border-b pb-5">
+          <Icon className="h-7 w-7 shrink-0 text-muted-foreground" />
+          <h1 className="text-2xl font-semibold leading-tight">
+            {diag?.title || diag?.name || 'Diagnosis'}
+          </h1>
+        </div>
+        <DiagnosisDetails diagnosisId={pointer} variant="page" />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/version-popover/diagnose-modal.tsx
+++ b/ui/src/components/version-popover/diagnose-modal.tsx
@@ -1,7 +1,13 @@
 import { DiagnosisActionButtons } from '@src/components/diagnose/diagnosis-action-buttons';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@src/components/ui/dialog';
 import { Textarea } from '@src/components/ui/textarea';
-import { ActionInfo, dataManager, FlowpadDiagnosis, sendDiagnosisReport } from '@sdk';
+import {
+  ActionInfo,
+  dataManager,
+  FlowpadDiagnosis,
+  sendDiagnosisEmailReport,
+  sendDiagnosisReport,
+} from '@sdk';
 import { streamDiagnose, type DiagnoseEvent } from '@src/components/diagnose/diagnose-stream';
 import { CheckCircle2, Info, Loader2, Stethoscope, XCircle } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -140,7 +146,23 @@ export function DiagnoseModal({ open, onClose, onViewDiagnosis }: DiagnoseModalP
   // formatted diagnostic report into the chosen conversation (the same send path
   // the Feed card uses), then close. The body comes from the recorded support
   // FlowMessage; the diagnosis summary is only the no-message fallback.
-  const handleReport = useCallback(
+  // "Report issue" — email the diagnosis to the Flowpad team.
+  const handleReportIssue = useCallback(async () => {
+    if (!done?.diagnosisId) return;
+    setReporting(true);
+    setReportError(undefined);
+    try {
+      await sendDiagnosisEmailReport(done.diagnosisId);
+      handleClose();
+    } catch (e) {
+      setReportError(e instanceof Error ? e.message : 'Failed to send report');
+    } finally {
+      setReporting(false);
+    }
+  }, [done, handleClose]);
+
+  // "Forward" — post the formatted report into the chosen conversation.
+  const handleForward = useCallback(
     async (conversationId: string) => {
       if (!done?.diagnosisId) return;
       setReporting(true);
@@ -266,10 +288,12 @@ export function DiagnoseModal({ open, onClose, onViewDiagnosis }: DiagnoseModalP
           {done?.ok && !handedToFeed && done.conversationId && (
             <DiagnosisActionButtons
               suggestedConversationId={done.conversationId}
+              canReport={!!done.diagnosisId}
               busy={reporting}
               error={reportError}
               onDismiss={handleClose}
-              onReport={(conversationId) => void handleReport(conversationId)}
+              onReportIssue={() => void handleReportIssue()}
+              onForward={(conversationId) => void handleForward(conversationId)}
             />
           )}
 

--- a/ui/src/components/version-popover/diagnosis-report-modal.tsx
+++ b/ui/src/components/version-popover/diagnosis-report-modal.tsx
@@ -1,8 +1,11 @@
-import { DiagnosisActionButtons } from '@src/components/diagnose/diagnosis-action-buttons';
+import { DiagnosisDetails } from '@src/components/diagnose/diagnosis-details';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@src/components/ui/dialog';
-import { FlowpadDiagnosis, sendDiagnosisReport } from '@sdk';
-import { Loader2, Stethoscope } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { FlowpadDiagnosis, TypeId } from '@sdk';
+import { useEntity } from '@sdk/react/hooks';
+import { DockPointer } from '@src/navigation/DockPointer';
+import { useDockNavigation } from '@src/navigation/useDockNavigation';
+import { Maximize2, Stethoscope } from 'lucide-react';
+import { useMemo } from 'react';
 
 interface DiagnosisReportModalProps {
   open: boolean;
@@ -14,16 +17,12 @@ interface DiagnosisReportModalProps {
   onClose: () => void;
 }
 
-interface Field {
-  label: string;
-  value?: string;
-}
-
 /**
- * The "View diagnosis" popup, opened from the finished-diagnose modal in place of
- * it. Shows the full recorded diagnosis (title / summary / symptoms / root cause /
- * fix) and — for a real issue — the same report buttons as a Feed entry, wired to
- * the diagnosis's support conversation.
+ * The "View diagnosis" popup. Shows the recorded diagnosis (title / summary /
+ * symptoms / root cause / fix) via the shared `DiagnosisDetails` body — Copy and,
+ * for a real issue, the same Report/Forward buttons as a Feed entry. The expand
+ * arrow promotes the popup into the full URL tab (`/dock/diagnosis/<id>`), closing
+ * the overlay — the same content, now a first-class entity view.
  */
 export function DiagnosisReportModal({
   open,
@@ -32,94 +31,49 @@ export function DiagnosisReportModal({
   flowMessageId,
   onClose,
 }: DiagnosisReportModalProps) {
-  const [diag, setDiag] = useState<FlowpadDiagnosis | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [reporting, setReporting] = useState(false);
-  const [reportError, setReportError] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!open || !diagnosisId) return;
-    let cancelled = false;
-    setLoading(true);
-    setReportError(undefined);
-    void FlowpadDiagnosis.getById<FlowpadDiagnosis>(diagnosisId)
-      .then((d) => {
-        if (!cancelled) setDiag(d ?? null);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, diagnosisId]);
-
-  const handleReport = useCallback(
-    async (targetConversationId: string) => {
-      setReporting(true);
-      setReportError(undefined);
-      try {
-        await sendDiagnosisReport(targetConversationId, {
-          flowMessageId,
-          fallbackText: diag?.summary || diag?.title || '',
-        });
-        onClose();
-      } catch (e) {
-        setReportError(e instanceof Error ? e.message : 'Failed to send report');
-      } finally {
-        setReporting(false);
-      }
-    },
-    [diag, flowMessageId, onClose],
+  const { navigation } = useDockNavigation();
+  const typeId = useMemo(
+    () => (diagnosisId ? new TypeId(FlowpadDiagnosis.type, diagnosisId) : null),
+    [diagnosisId],
   );
+  const { data: diag } = useEntity<FlowpadDiagnosis>(typeId, { enabled: open && !!typeId });
 
-  const fields: Field[] = [
-    { label: 'Summary', value: diag?.summary },
-    { label: 'Symptoms', value: diag?.symptoms },
-    { label: 'Root cause', value: diag?.rca },
-    { label: 'Fix', value: diag?.fix },
-  ];
+  const handleExpand = () => {
+    if (!diagnosisId) return;
+    navigation.openDock(DockPointer.forDiagnosis(diagnosisId));
+    onClose();
+  };
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Stethoscope className="h-4 w-4" />
-            {diag?.title || 'Diagnosis'}
+        <DialogHeader className="min-w-0">
+          <DialogTitle className="flex items-center gap-2 pr-6">
+            <Stethoscope className="h-4 w-4 shrink-0" />
+            <span className="min-w-0 flex-1 truncate">{diag?.title || 'Diagnosis'}</span>
+            <button
+              type="button"
+              onClick={handleExpand}
+              disabled={!diagnosisId}
+              title="Open as a tab"
+              aria-label="Open diagnosis as a tab"
+              className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+            >
+              <Maximize2 className="h-4 w-4" />
+            </button>
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-3">
-          {loading ? (
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              <span>Loading diagnosis…</span>
+        <div className="min-w-0 space-y-3">
+          {diagnosisId && (
+            <div className="max-h-[55vh] overflow-y-auto overflow-x-hidden pr-1">
+              <DiagnosisDetails
+                diagnosisId={diagnosisId}
+                conversationId={conversationId}
+                flowMessageId={flowMessageId}
+                onActionDone={onClose}
+              />
             </div>
-          ) : (
-            <div className="max-h-[55vh] space-y-3 overflow-y-auto pr-1">
-              {fields
-                .filter((f) => f.value)
-                .map((f) => (
-                  <div key={f.label}>
-                    <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                      {f.label}
-                    </p>
-                    <p className="whitespace-pre-wrap break-words text-xs text-foreground">{f.value}</p>
-                  </div>
-                ))}
-            </div>
-          )}
-
-          {/* Same report buttons as a Feed entry — only when there's an issue to report. */}
-          {conversationId && (
-            <DiagnosisActionButtons
-              suggestedConversationId={conversationId}
-              busy={reporting}
-              error={reportError}
-              onDismiss={onClose}
-              onReport={(targetConversationId) => void handleReport(targetConversationId)}
-            />
           )}
 
           <div className="flex justify-end">

--- a/ui/src/navigation/DockPointer.ts
+++ b/ui/src/navigation/DockPointer.ts
@@ -703,6 +703,14 @@ export class DockPointer implements IDockPointer {
     return new DockPointer(ViewType.GRAPH_CONTEXT, id, undefined, layout);
   }
 
+  /**
+   * Create a DockPointer for the diagnosis viewer at `/dock/diagnosis/<id>`.
+   * `id` is the FlowpadDiagnosis entity's UUID.
+   */
+  static forDiagnosis(id: string, layout: Layout = Layout.DOCK): DockPointer {
+    return new DockPointer(ViewType.DIAGNOSIS, id, undefined, layout);
+  }
+
   /** Split a GRAPH pointer into its `{ type, id }` parts. */
   static parseGraphPointer(pointer: string | undefined): { type: string; id: string } | null {
     if (!pointer) return null;

--- a/ui/src/pages/flow-page/content-panel/content-panel.tsx
+++ b/ui/src/pages/flow-page/content-panel/content-panel.tsx
@@ -46,6 +46,7 @@ import { DockPointer } from '@src/navigation/DockPointer';
 import { useDockNavigation } from '@src/navigation/useDockNavigation';
 import { SpecRoute } from '@src/pages/spec/SpecRoute';
 import { GraphContextViewer } from '@src/components/graph-context/GraphContextViewer';
+import { DiagnosisViewer } from '@src/components/diagnosis-viewer/DiagnosisViewer';
 import { useSendMessageStore } from '@src/store/use-send-message-store';
 import { useSurveyStore } from '@src/store/use-survey-store';
 import { TabLifecycleState, useTabLifecycle } from '@src/tabs/tab-lifecycle';
@@ -336,6 +337,8 @@ export function ContentPanel() {
         return <SpecRoute />;
       case ViewType.GRAPH_CONTEXT:
         return <GraphContextViewer pointer={currentDock?.pointer} />;
+      case ViewType.DIAGNOSIS:
+        return <DiagnosisViewer pointer={currentDock?.pointer} />;
       case ViewType.HOME:
       default:
         return <HomeLanding />;

--- a/ui/src/pages/home-landing/feed/FeedEntryCard.tsx
+++ b/ui/src/pages/home-landing/feed/FeedEntryCard.tsx
@@ -1,5 +1,6 @@
 import { DiagnosisActionButtons } from '@src/components/diagnose/diagnosis-action-buttons';
-import { ChevronDown, ChevronRight, EyeOff } from 'lucide-react';
+import { DiagnosisReportModal } from '@src/components/version-popover/diagnosis-report-modal';
+import { ChevronDown, ChevronRight, Eye, EyeOff } from 'lucide-react';
 import { useMemo, useState, type ReactNode } from 'react';
 import { AgentTrace, FlowMessage, MessageSuggest, UsageReport, UserNote, type FeedEntry } from '@sdk';
 import { formatDuration } from '@src/components/lens-viewer/shared/format-utils';
@@ -15,7 +16,10 @@ interface FeedEntryCardProps {
   busy: boolean;
   error?: string;
   onDismiss: (entry: FeedEntry) => void;
-  onReportMessageSuggest: (entry: FeedEntry, suggest: MessageSuggest, conversationId: string) => void;
+  /** "Report issue" — email the diagnosis to the Flowpad team. */
+  onReportIssue: (entry: FeedEntry, suggest: MessageSuggest) => void;
+  /** "Forward" — post the report into the chosen conversation. */
+  onForwardMessageSuggest: (entry: FeedEntry, suggest: MessageSuggest, conversationId: string) => void;
 }
 
 export function FeedEntryCard({
@@ -23,7 +27,8 @@ export function FeedEntryCard({
   busy,
   error,
   onDismiss,
-  onReportMessageSuggest,
+  onReportIssue,
+  onForwardMessageSuggest,
 }: FeedEntryCardProps) {
   const feedData = useMemo(() => FeedData.fromEntry(entry), [entry]);
   const targetTypeId = feedData.targetTypeId;
@@ -71,7 +76,8 @@ export function FeedEntryCard({
         error={error}
         feedData={feedData}
         onDismiss={onDismiss}
-        onReport={onReportMessageSuggest}
+        onReportIssue={onReportIssue}
+        onForward={onForwardMessageSuggest}
       />
     );
   }
@@ -172,7 +178,8 @@ interface MessageSuggestFeedEntryCardProps {
   error?: string;
   feedData: FeedData;
   onDismiss: (entry: FeedEntry) => void;
-  onReport: (entry: FeedEntry, suggest: MessageSuggest, conversationId: string) => void;
+  onReportIssue: (entry: FeedEntry, suggest: MessageSuggest) => void;
+  onForward: (entry: FeedEntry, suggest: MessageSuggest, conversationId: string) => void;
 }
 
 function MessageSuggestFeedEntryCard({
@@ -182,12 +189,30 @@ function MessageSuggestFeedEntryCard({
   error,
   feedData,
   onDismiss,
-  onReport,
+  onReportIssue,
+  onForward,
 }: MessageSuggestFeedEntryCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const [viewOpen, setViewOpen] = useState(false);
   const title = suggest.text ?? 'Flowpad diagnostics';
   const body = suggest.message_text ?? '';
   const expandable = body.length > 80 || body.includes('\n');
+  const isDiagnosis = suggest.kind !== 'draft_reply';
+
+  const viewButton =
+    isDiagnosis && suggest.diagnosis_id ? (
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={busy}
+        onClick={() => setViewOpen(true)}
+        className="h-6 gap-1 px-2 text-xs"
+      >
+        <Eye className="h-3.5 w-3.5" />
+        View
+      </Button>
+    ) : null;
 
   return (
     <FeedEntryFrame entry={entry} busy={busy} feedData={feedData} onDismiss={onDismiss}>
@@ -257,16 +282,36 @@ function MessageSuggestFeedEntryCard({
           draftFlowMessageId={suggest.flow_message_id}
           onDone={() => onDismiss(entry)}
         />
-      ) : suggest.conversation_id ? (
-        <DiagnosisActionButtons
-          suggestedConversationId={suggest.conversation_id}
-          busy={busy}
-          error={error}
-          showDismiss={false}
-          onDismiss={() => onDismiss(entry)}
-          onReport={(conversationId) => onReport(entry, suggest, conversationId)}
-        />
-      ) : null}
+      ) : (
+        <>
+          {/* View opens the diagnosis popup, right-most on the Report/Forward row.
+              Report/Forward never dismiss the card (only the frame's eye-off does). */}
+          {isDiagnosis && suggest.conversation_id ? (
+            <DiagnosisActionButtons
+              suggestedConversationId={suggest.conversation_id}
+              busy={busy}
+              error={error}
+              showDismiss={false}
+              canReport={!!suggest.diagnosis_id}
+              onDismiss={() => onDismiss(entry)}
+              onReportIssue={() => onReportIssue(entry, suggest)}
+              onForward={(conversationId) => onForward(entry, suggest, conversationId)}
+              trailing={viewButton}
+            />
+          ) : (
+            viewButton && <div className="mt-2 flex justify-end">{viewButton}</div>
+          )}
+          {isDiagnosis && suggest.diagnosis_id && (
+            <DiagnosisReportModal
+              open={viewOpen}
+              diagnosisId={suggest.diagnosis_id}
+              conversationId={suggest.conversation_id ?? undefined}
+              flowMessageId={suggest.flow_message_id ?? undefined}
+              onClose={() => setViewOpen(false)}
+            />
+          )}
+        </>
+      )}
     </FeedEntryFrame>
   );
 }

--- a/ui/src/pages/home-landing/feed/HomeFeedColumn.tsx
+++ b/ui/src/pages/home-landing/feed/HomeFeedColumn.tsx
@@ -4,6 +4,7 @@ import {
   QueryRequest,
   UserNote,
   sendDiagnosisReport,
+  sendDiagnosisEmailReport,
   type EntityFeedData,
 } from '@sdk';
 import { useEntitiesQuery } from '@src/hooks/entity-hooks';
@@ -58,16 +59,15 @@ export function HomeFeedColumn() {
     [dismiss],
   );
 
-  const handleReportMessageSuggest = useCallback(
-    async (entry: FeedEntry, suggest: MessageSuggest, conversationId: string) => {
+  // "Report issue" — email the diagnosis to the Flowpad team (via the backend
+  // `report` action → hub → SendGrid). Does NOT dismiss the card (only eye-off does).
+  const handleReportIssue = useCallback(
+    async (entry: FeedEntry, suggest: MessageSuggest) => {
+      if (!suggest.diagnosis_id) return;
       setBusyId(entry.id ?? null);
       setSendError(null);
       try {
-        await sendDiagnosisReport(conversationId, {
-          flowMessageId: suggest.flow_message_id ?? undefined,
-          fallbackText: suggest.message_text ?? '',
-        });
-        await dismiss(entry);
+        await sendDiagnosisEmailReport(suggest.diagnosis_id);
       } catch (err: unknown) {
         setSendError({
           entryId: entry.id ?? '',
@@ -77,7 +77,30 @@ export function HomeFeedColumn() {
         setBusyId(null);
       }
     },
-    [dismiss],
+    [],
+  );
+
+  // "Forward" — post the formatted report into the chosen conversation.
+  const handleForwardMessageSuggest = useCallback(
+    async (entry: FeedEntry, suggest: MessageSuggest, conversationId: string) => {
+      setBusyId(entry.id ?? null);
+      setSendError(null);
+      try {
+        await sendDiagnosisReport(conversationId, {
+          flowMessageId: suggest.flow_message_id ?? undefined,
+          fallbackText: suggest.message_text ?? '',
+        });
+        // Report/Forward no longer dismiss the card — only the eye-off button does.
+      } catch (err: unknown) {
+        setSendError({
+          entryId: entry.id ?? '',
+          message: err instanceof Error ? err.message : 'Failed to send report',
+        });
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [],
   );
 
   const handleCreateNote = useCallback(
@@ -156,8 +179,9 @@ export function HomeFeedColumn() {
                 busy={busyId === entry.id}
                 error={sendError?.entryId === entry.id ? sendError.message : undefined}
                 onDismiss={(item) => void handleDismiss(item)}
-                onReportMessageSuggest={(item, suggest, conversationId) =>
-                  void handleReportMessageSuggest(item, suggest, conversationId)
+                onReportIssue={(item, suggest) => void handleReportIssue(item, suggest)}
+                onForwardMessageSuggest={(item, suggest, conversationId) =>
+                  void handleForwardMessageSuggest(item, suggest, conversationId)
                 }
               />
             ))}

--- a/ui/src/types/ViewType.ts
+++ b/ui/src/types/ViewType.ts
@@ -71,7 +71,8 @@ export interface ViewerMeta {
     | 'GitGraph'
     | 'BrainCircuit'
     | 'Users'
-    | 'Inbox';
+    | 'Inbox'
+    | 'Stethoscope';
   /** Where this viewer renders: 'overview' tab or dedicated tab */
   tabLocation: 'overview' | 'dedicated';
   /** Can this viewer be manually added as a tab? */
@@ -348,6 +349,12 @@ export const VIEWER_REGISTRY: Partial<Record<ViewType, ViewerMeta>> = {
   [ViewType.GRAPH_CONTEXT]: {
     title: 'Context',
     iconName: 'BrainCircuit',
+    tabLocation: 'dedicated',
+    canAddAsTab: false,
+  },
+  [ViewType.DIAGNOSIS]: {
+    title: 'Diagnosis',
+    iconName: 'Stethoscope',
     tabLocation: 'dedicated',
     canAddAsTab: false,
   },


### PR DESCRIPTION
## Summary

Makes a recorded `FlowpadDiagnosis` a first-class, URL-navigable entity (like skills/conversations) and reworks the diagnosis **Report** action into an email to the Flowpad team. Bundles two related pieces under FLOWPAD-1896.

### Diagnosis viewer
- **New URL viewer** `/dock/diagnosis/<id>` — `DIAGNOSIS` added to the `ViewType` enum + `VIEWER_REGISTRY` (Stethoscope icon), `DockPointer.forDiagnosis`, a `renderBody` case, and the routed `DiagnosisViewer`.
- **One shared body** (`diagnosis-details.tsx`) used by the popup, the routed tab, and the feed — title + Summary/Symptoms/Root cause/Fix, a **Copy** button, and the Report/Forward actions. A `page` variant gives the full tab document-style typography (larger font, looser line spacing, centered reading column); the popup stays compact.
- **Popup → expand**: the "View diagnosis" popup gets a Maximize arrow that closes the overlay and opens the routed tab. (Grid-overflow bug in the dialog fixed via `min-w-0`.)
- **Settings → System Diagnoses table**: fixed-width columns (no horizontal scroll), row-click opens the viewer, and per-row actions **View / Report / Forward / Copy-all / Delete** (trash icon). The list is now a **reactive** `useEntitiesQuery`, so deletes and newly recorded diagnoses reflect automatically.
- **Home feed**: every diagnosis card gets a **View** button (right-most on the Report/Forward row), backed by a new `diagnosis_id` field on `MessageSuggest`. Report/Forward no longer dismiss the card — only the eye-off does.

### Email report
- **Report issue** now emails the diagnosis to the Flowpad team (`sendDiagnosisEmailReport` → backend `report` action → hub → SendGrid) instead of posting into the support conversation. **Forward** still posts the formatted report into a chosen conversation.

## Test plan
- Run a diagnosis → View diagnosis → Copy → expand to `/dock/diagnosis/<id>` tab; reload the URL.
- Settings → System Diagnoses: table fits with no horizontal scroll; exercise View / Report (email) / Forward (conversation picker) / Copy-all / Delete; confirm the row disappears on delete without a manual refresh.
- Home feed diagnosis card: View opens the popup; Report/Forward keep the card; eye-off dismisses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)